### PR TITLE
Fix MSVC C++ 20 compiler issue

### DIFF
--- a/Source/MapIntrospector.h
+++ b/Source/MapIntrospector.h
@@ -95,7 +95,7 @@ template<class _Maptype>
 class MapIntrospector: private _Maptype {
 public:
 	static size_t GetNodesMemorySize(size_t node_count) {
-		return (node_count + 1) * sizeof(_Node);
+		return (node_count + 1) * sizeof(_Maptype::_Node);
 	}
 };
 


### PR DESCRIPTION
HI! It seems that the build is broken with the latest visual c++ compiler when enabling C++20.

# What is the error log

```
C:\Users\edukaj\.conan2\p\b\freei373179c09645a\b\src\Source\MapIntrospector.h(98,36): error C2065: '_Node': undeclared identifier [C:\Users\edukaj\
.conan2\p\b\freei373179c09645a\b\build\FreeImage.vcxproj]
  ConversionRGBF.cpp
  (compiling source file '../src/Source/FreeImage/BitmapAccess.cpp')
  C:\Users\edukaj\.conan2\p\b\freei373179c09645a\b\src\Source\MapIntrospector.h(98,36):
  the template instantiation context (the oldest one first) is
        C:\Users\edukaj\.conan2\p\b\freei373179c09645a\b\src\Source\MapIntrospector.h(95,7):
        while compiling class template 'MapIntrospector'

C:\Users\edukaj\.conan2\p\b\freei373179c09645a\b\src\Source\MapIntrospector.h(98,36): error C3861: '_Node': identifier not found [C:\Users\edukaj\.
conan2\p\b\freei373179c09645a\b\build\FreeImage.vcxproj]
  (compiling source file '../src/Source/FreeImage/BitmapAccess.cpp')
```

# What is my setup:

```
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=20
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=193
os=Windows
```

# How can I reproduce it?

Simply use Visual C++ with C++20 enabled and start the build.

# What is wrong?

FreeImage needs to understand the footprint of the map to understand the size of a bitmap. In the [following line of code](https://github.com/WinMerge/freeimage/blob/master/Source/MapIntrospector.h#L98) `MapIntrospector` derives from `std::map` but the field `_Node` seems not anymore exposed when building with C++20,
