### PR TITLE
Fix MSVC C++ 20 compiler issue in TestAPI

### DIFF
--- a/TestAPI/testMPageMemory.cpp
+++ b/TestAPI/testMPageMemory.cpp
@@ -161,7 +161,7 @@ loadBuffer(const char *lpszPathName, BYTE **buffer, DWORD *length) {
 	return FALSE;
 }
 
-BOOL testMemoryStreamMultiPageOpenSave(const char *lpszPathName, char *output, int input_flag, int output_flag) {
+BOOL testMemoryStreamMultiPageOpenSave(const char *lpszPathName, const char *output, int input_flag, int output_flag) {
 	BOOL bSuccess = FALSE;
 
 	BYTE *buffer = NULL;


### PR DESCRIPTION
Even after merging #7, https://github.com/tbeu/FreeImage/actions/runs/8365814653 made another MSVC C++20 issue apparent if built with `-DBUILD_TESTS=ON`.

There's the green run: https://github.com/tbeu/FreeImage/actions/runs/8365884805