### PR TITLE
Fix heap-buffer-overflow read in TARGA RLE loader

### DIFF
--- a/Source/FreeImage/PluginTARGA.cpp
+++ b/Source/FreeImage/PluginTARGA.cpp
@@ -593,7 +593,13 @@ loadRLE(FIBITMAP*& dib, int width, int height, FreeImageIO* io, fi_handle handle
 	if (remaining_size < height) {
 		throw FI_MSG_ERROR_CORRUPTED;
 	}
-	const long sz = (remaining_size / height);
+	long sz = (remaining_size / height);
+
+	// Ensure the cache is at least one pixel wide to prevent
+	// out-of-bounds reads when getBytes(file_pixel_size) is called.
+	if (sz < file_pixel_size) {
+		sz = file_pixel_size;
+	}
 
 	// ...and allocate cache of this size (yields good results)
 	IOCache cache(io, handle, sz);


### PR DESCRIPTION
## Summary

When loading a malformed TGA file whose declared image dimensions exceed the actual remaining pixel data, the `IOCache` buffer size computed as `(remaining_size / height)` can be smaller than a single pixel. The RLE decoder then calls `getBytes(file_pixel_size)` and reads past the end of the undersized buffer.

## Root cause

`PluginTARGA.cpp` line 596: `const long sz = (remaining_size / height);` — if `remaining_size` is small relative to `height`, `sz` can be less than `file_pixel_size` (e.g. 1 byte for a 24-bpp image that needs 3 bytes per pixel).

## Fix

Clamp the cache size to at least `file_pixel_size` so that every `getBytes` call reads within bounds.

## Metadata

- **CWE**: CWE-122 (Heap-based Buffer Overflow)
- **Severity**: High
- **Reproducer**: 21-byte malformed TGA file (available on request)
- **Found during**: academic security research
- **ASan trace**: `_assignPixel<24>` at `PluginTARGA.cpp:547`, called from `loadRLE<24>` at line 651