### PR TITLE
Fix heap-buffer-overflow write in CUT RLE parser

### DIFF
--- a/Source/FreeImage/PluginCUT.cpp
+++ b/Source/FreeImage/PluginCUT.cpp
@@ -166,6 +166,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 
 			if (count == 0) {
 				k = 0;
+				// Guard against pointer underflow: do not move past
+				// the first scanline of the allocated bitmap.
+				if (bits < FreeImage_GetBits(dib) + pitch) {
+					break;
+				}
 				bits -= pitch;
 
 				// paint shop pro adds two useless bytes here...


### PR DESCRIPTION
## Summary

The CUT (Dr. Halo) format parser allocates a bitmap from the file header (`width * height`). During RLE decompression, a zero-count byte triggers `bits -= pitch` to move to the previous scanline. If the header declares `height=1` but the RLE data contains multiple zero-count markers, the scanline pointer underflows below the heap allocation, causing an out-of-bounds write on the subsequent `memset` or `read_proc` call.

## Root cause

`PluginCUT.cpp` line 169: `bits -= pitch;` — no check that `bits` remains within the allocated bitmap before decrementing.

## Fix

Add a bounds check before the decrement: verify that `bits` is at least `pitch` bytes above the start of the bitmap data. If not, break out of the decompression loop.

## Metadata

- **CWE**: CWE-787 (Out-of-bounds Write)
- **Severity**: Critical (CVSS 8.8)
- **Reproducer**: 24-byte CUT file with `width=0x230B`, `height=0x0001` (available on request)
- **Found during**: academic security research
- **ASan trace**: SEGV via `memcpy` at `PluginCUT.cpp:193`, triggered by `_MemoryReadProc`