### PR TITLE
Fix heap-buffer-overflow write in PICT UnpackPictRow

### DIFF
--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -560,7 +560,14 @@ UnpackPictRow( FreeImageIO *io, fi_handle handle, BYTE* pLineBuf, int width, int
 					// Packed data.
 					int len = ((FlagCounter ^ 255) & 255) + 2;					
 					BYTE p = Read8( io, handle );
-					memset( pCurPixel, p, len);
+					// Clamp to remaining buffer to prevent out-of-bounds write
+					int remaining = (int)(pLineBuf + rowBytes - pCurPixel);
+					if (len > remaining) {
+						len = remaining;
+					}
+					if (len > 0) {
+						memset( pCurPixel, p, len);
+					}
 					pCurPixel += len;
 					j += 2;
 				}
@@ -568,7 +575,14 @@ UnpackPictRow( FreeImageIO *io, fi_handle handle, BYTE* pLineBuf, int width, int
 			else { 
 				// Unpacked data
 				int len = (FlagCounter & 255) + 1;
-				io->read_proc( pCurPixel, len, 1, handle );
+				// Clamp to remaining buffer to prevent out-of-bounds write
+				int remaining = (int)(pLineBuf + rowBytes - pCurPixel);
+				if (len > remaining) {
+					len = remaining;
+				}
+				if (len > 0) {
+					io->read_proc( pCurPixel, len, 1, handle );
+				}
 				pCurPixel += len;
 				j += len + 1;
 			}


### PR DESCRIPTION
## Summary

The PackBits decompression loop in `UnpackPictRow` advances `pCurPixel` by the decoded run length without verifying that the destination remains within the allocated line buffer (`pLineBuf`, sized to `rowBytes`). A crafted PICT file with run lengths that exceed the scanline width causes `memset` (packed path) or `read_proc` (unpacked path) to write past the end of the buffer.

## Root cause

`PluginPICT.cpp` lines 562 and 571: the decoded `len` is used directly in `memset`/`read_proc` without clamping to the remaining buffer space.

## Fix

Clamp the decoded length to the remaining buffer space (`pLineBuf + rowBytes - pCurPixel`) before each write operation, in both the packed-data and unpacked-data code paths. Skip the write entirely if no space remains.

## Metadata

- **CWE**: CWE-787 (Out-of-bounds Write)
- **Severity**: High
- **Reproducer**: crafted PICT file (available on request)
- **Found during**: academic security research