### PR TITLE
Patch for LibPNG macOS removal of ancient header

### DIFF
--- a/Source/LibPNG/pngpriv.h
+++ b/Source/LibPNG/pngpriv.h
@@ -515,25 +515,15 @@
     */
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-   /* We need to check that <math.h> hasn't already been included earlier
-    * as it seems it doesn't agree with <fp.h>, yet we should really use
-    * <fp.h> if possible.
-    */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
-#    include <math.h>
-#  endif
-#  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+/* Floating point headers — <fp.h> was removed from macOS SDK */
+# include <math.h>
+
+# if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
     * MATH=68881
     */
-#    include <m68881.h>
-#  endif
-#endif
+# include <m68881.h>
+# endif
 
 /* This provides the non-ANSI (far) memory allocation routines. */
 #if defined(__TURBOC__) && defined(__MSDOS__)

--- a/Source/LibPNG/pngpriv.h
+++ b/Source/LibPNG/pngpriv.h
@@ -515,15 +515,22 @@
     */
 #  include <float.h>
 
-/* Floating point headers — <fp.h> was removed from macOS SDK */
-# include <math.h>
-
-# if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+#if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+   /* <fp.h> was removed in macOS 15+ / Xcode 16+. The floating-point
+    * functions it provided are now in <math.h>.
+    */
+#    include <math.h>
+#  else
+#    include <math.h>
+#  endif
+#  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
     * MATH=68881
     */
-# include <m68881.h>
-# endif
+#    include <m68881.h>
+#  endif
+#endif
 
 /* This provides the non-ANSI (far) memory allocation routines. */
 #if defined(__TURBOC__) && defined(__MSDOS__)


### PR DESCRIPTION
macOS 15+ / Xcode 16+ (and later) because the SDK no longer ships the ancient header

This started happening on macOS 15+ / Xcode 16+ (and later) because the SDK no longer ships the ancient header 
```<fp.h>``` 
FreeImage 3.18.0 (the current release) still ships LibPNG 1.6.x pre-1.6.45, which unconditionally tries to #include <fp.h> on Apple platforms.

This quick hotfix just moves to ```math.h```