### PR TITLE
CWE-787 - Fix heap-buffer-overflow write in PICT UnpackBits

### DIFF
--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -756,7 +756,13 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 			}
 		}
 		else {
-			for ( int i = 0; i < height; i++ ) { 
+			// CWE-787: bound every PackBits write to the allocated raster.
+			// The RLE run length is attacker-controlled and the loop below
+			// advances dst without checking it against the bitmap bounds.
+			BYTE* const rasterStart = FreeImage_GetBits( dib );
+			BYTE* const rasterEnd = rasterStart +
+				(size_t)FreeImage_GetPitch( dib ) * FreeImage_GetHeight( dib );
+			for ( int i = 0; i < height; i++ ) {
 				// For each line do...
 				int    linelen;            // length of source line in bytes.
 				if (rowBytes > 250) {
@@ -784,16 +790,22 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 							
 							// This is slow for some formats...
 							if (pixelSize == 16) {
+								if (dst < rasterStart ||
+									(size_t)(rasterEnd - dst) < (size_t)len*4*PixelPerRLEUnit)
+									break;
 								expandBuf( io, handle, 1, pixelSize, dst );
-								for ( int k = 1; k < len; k++ ) { 
+								for ( int k = 1; k < len; k++ ) {
 									// Repeat the pixel len times.
 									memcpy( dst+(k*4*PixelPerRLEUnit), dst,	4*PixelPerRLEUnit);
 								}
 								dst += len*4*PixelPerRLEUnit;
 							}
 							else {
+								if (dst < rasterStart ||
+									(size_t)(rasterEnd - dst) < (size_t)len*PixelPerRLEUnit)
+									break;
 								expandBuf8( io, handle, 1, pixelSize, dst );
-								for ( int k = 1; k < len; k++ ) { 
+								for ( int k = 1; k < len; k++ ) {
 									// Repeat the expanded byte len times.
 									memcpy( dst+(k*PixelPerRLEUnit), dst, PixelPerRLEUnit);
 								}
@@ -806,10 +818,16 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 						// Unpacked data
 						int len = (FlagCounter & 255) + 1;
 						if (pixelSize == 16) {
+							if (dst < rasterStart ||
+								(size_t)(rasterEnd - dst) < (size_t)len*4*PixelPerRLEUnit)
+								break;
 							expandBuf( io, handle, len, pixelSize, dst );
 							dst += len*4*PixelPerRLEUnit;
 						}
 						else {
+							if (dst < rasterStart ||
+								(size_t)(rasterEnd - dst) < (size_t)len*PixelPerRLEUnit)
+								break;
 							expandBuf8( io, handle, len, pixelSize, dst );
 							dst += len*PixelPerRLEUnit;
 						}


### PR DESCRIPTION
Sibling of merged PR #41 (UnpackPictRow). `UnpackBits` in `Source/FreeImage/PluginPICT.cpp` has the same unbounded-run defect: its per-row PackBits loop advances `dst` into the bitmap raster by an attacker-controlled run length with no check against the end of the raster, so a crafted PICT whose row decompresses past the image writes out of bounds on the heap (reachable via `FreeImage_Load`).

`UnpackBits` is the decoder used for 1/2/4/16-bpp PICT data; the 8/32-bpp paths already go through the bounded `UnpackPictRow` fixed in #41. It is reachable from both the version-1 bitmap opcode (0x98) and the version-2 DirectBitsRect/PackBitsRect opcodes (0x9a/0x98), so it triggers through normal content-sniffing format detection.

This PR bounds every write in the `UnpackBits` RLE loop to the allocated raster, exactly like #41: compute `rasterEnd = FreeImage_GetBits(dib) + pitch * height` once, and break out of the row loop if a run would write past it, in both the packed-data and unpacked-data code paths.

Verified: a PICT that previously triggered an AddressSanitizer heap-buffer-overflow now decodes without any out-of-bounds access, and well-formed PICT images still decode.

CWE-787 (out-of-bounds heap write); denial-of-service / memory corruption (the reachable write content is constrained, so this is not code execution).
