### PR TITLE
CWE-457 - Fix uninitialized memory read in PCX loader (planes=3, bpp=8)

### DIFF
--- a/Source/FreeImage/PluginPCX.cpp
+++ b/Source/FreeImage/PluginPCX.cpp
@@ -598,6 +598,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		} else if((header.planes == 3) && (header.bpp == 8)) {
 			BYTE *pLine;
 
+			// sanity check: each plane provides header.bytes_per_line bytes, but the
+			// BGR expansion below reads pLine[x] for x in [0,width). Reject inputs
+			// where width exceeds bytes_per_line to avoid a heap over-read on `line`.
+			if (width > header.bytes_per_line) {
+				throw FI_MSG_ERROR_PARSING;
+			}
+
 			for (unsigned y = 0; y < height; y++) {
 				readLine(io, handle, line, lineLength, bIsRLE, ReadBuf, &ReadPos);
 


### PR DESCRIPTION
Prevent information disclosure caused by reading uninitialized heap memory when width > bytes_per_line in 8-bit 3-plane PCX images. The existing MAX over-allocation only masked the out-of-bounds read but did not prevent uninitialized bytes from leaking into pixel data.

Add a validation check that rejects images where width exceeds bytes_per_line, as each plane provides only bytes_per_line bytes but the BGR expansion loop indexes by width.

CWE-457 (use of uninitialized variable)
Found during academic security research.

Fixes: #49