### PR TITLE
CVE-2024-28584 - Fix NULL pointer dereference in JPEG2000 loader

### DIFF
--- a/Source/FreeImage/J2KHelper.cpp
+++ b/Source/FreeImage/J2KHelper.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 helpers
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -127,6 +127,13 @@ FIBITMAP* J2KImageToFIBITMAP(int format_id, const opj_image_t *image, BOOL heade
 	FIBITMAP *dib = NULL;
 
 	try {
+		// opj_read_header() can return success while still leaving *image
+		// NULL for some malformed codestreams - guard against the NULL
+		// pointer dereference below rather than trusting callers to check.
+		if (!image) {
+			throw FI_MSG_ERROR_CORRUPTED_IMAGE;
+		}
+
 		// check the number of components
 		int numcomps = image->numcomps;
 		if (numcomps < 1) {

--- a/Source/FreeImage/J2KHelper.cpp
+++ b/Source/FreeImage/J2KHelper.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 helpers
 //
 // Design and implementation by
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -128,8 +128,7 @@ FIBITMAP* J2KImageToFIBITMAP(int format_id, const opj_image_t *image, BOOL heade
 
 	try {
 		// opj_read_header() can return success while still leaving *image
-		// NULL for some malformed codestreams - guard against the NULL
-		// pointer dereference below rather than trusting callers to check.
+		// NULL for some malformed codestreams
 		if (!image) {
 			throw FI_MSG_ERROR_CORRUPTED_IMAGE;
 		}

--- a/Source/FreeImage/PluginJ2K.cpp
+++ b/Source/FreeImage/PluginJ2K.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 J2K codestream Loader and Writer
 //
 // Design and implementation by
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginJ2K.cpp
+++ b/Source/FreeImage/PluginJ2K.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 J2K codestream Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -167,6 +167,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			
 			// read the main header of the codestream and if necessary the JP2 boxes
 			if( !opj_read_header(d_stream, d_codec, &image)) {
+				throw "Failed to read the header\n";
+			}
+			// opj_read_header() can report success while leaving image NULL
+			// for some malformed codestreams
+			if( !image ) {
 				throw "Failed to read the header\n";
 			}
 

--- a/Source/FreeImage/PluginJP2.cpp
+++ b/Source/FreeImage/PluginJP2.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 JP2 file format Loader and Writer
 //
 // Design and implementation by
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginJP2.cpp
+++ b/Source/FreeImage/PluginJP2.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 JP2 file format Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -167,6 +167,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			
 			// read the main header of the codestream and if necessary the JP2 boxes
 			if( !opj_read_header(d_stream, d_codec, &image)) {
+				throw "Failed to read the header\n";
+			}
+			// opj_read_header() can report success while leaving image NULL
+			// for some malformed codestreams
+			if( !image ) {
 				throw "Failed to read the header\n";
 			}
 


### PR DESCRIPTION
`opj_read_header()` can report success while leaving `image` NULL on malformed J2K/JP2 codestreams. Neither loader checked before passing it into `opj_decode()` / `J2KImageToFIBITMAP()`, which dereferences `image->numcomps` — a crash on a crafted file.

Adds the missing NULL check right after `opj_read_header()` in both `PluginJ2K.cpp` and `PluginJP2.cpp`, plus a defense-in-depth guard inside `J2KImageToFIBITMAP()` itself since both plugins call it.

| CVE | Link |
|---|---|
| CVE-2024-28584 | https://nvd.nist.gov/vuln/detail/CVE-2024-28584 |

Fixes: CVE-2024-28584
