### PR TITLE
CVE-2020-22524 - Fix integer overflow leading to undersized allocation in PFM loader

### DIFF
--- a/Source/FreeImage/PluginPFM.cpp
+++ b/Source/FreeImage/PluginPFM.cpp
@@ -2,7 +2,7 @@
 // PFM Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -271,7 +271,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		// Read the image...
 
 		if(image_type == FIT_RGBF) {
-			const unsigned lineWidth = 3 * width;
+			// Compute in size_t (not int/unsigned) so a large, attacker-
+			// controlled width can't silently overflow the 32-bit multiply
+			// before it reaches malloc()'s size argument - an overflowed,
+			// too-small lineWidth here would still let the per-pixel unpack
+			// loop below (bounded by the untruncated `width`) read past the
+			// end of this smaller-than-expected lineBuffer allocation.
+			const size_t lineWidth = (size_t)3 * (size_t)width;
 			lineBuffer = (float*)malloc(lineWidth * sizeof(float));
 			if(!lineBuffer) {
 				throw FI_MSG_ERROR_MEMORY;
@@ -305,7 +311,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			lineBuffer = NULL;
 
 		} else if(image_type == FIT_FLOAT) {
-			const unsigned lineWidth = width;
+			const size_t lineWidth = (size_t)width;
 			lineBuffer = (float*)malloc(lineWidth * sizeof(float));
 			if(!lineBuffer) {
 				throw FI_MSG_ERROR_MEMORY;

--- a/Source/FreeImage/PluginPFM.cpp
+++ b/Source/FreeImage/PluginPFM.cpp
@@ -2,7 +2,7 @@
 // PFM Loader and Writer
 //
 // Design and implementation by
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -271,12 +271,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		// Read the image...
 
 		if(image_type == FIT_RGBF) {
-			// Compute in size_t (not int/unsigned) so a large, attacker-
-			// controlled width can't silently overflow the 32-bit multiply
-			// before it reaches malloc()'s size argument - an overflowed,
-			// too-small lineWidth here would still let the per-pixel unpack
-			// loop below (bounded by the untruncated `width`) read past the
-			// end of this smaller-than-expected lineBuffer allocation.
+			// size_t avoids a 32-bit overflow of 3 * width
 			const size_t lineWidth = (size_t)3 * (size_t)width;
 			lineBuffer = (float*)malloc(lineWidth * sizeof(float));
 			if(!lineBuffer) {


### PR DESCRIPTION
`Load()` computed the PFM line buffer size as `3 * width` (int/unsigned), where `width` comes straight from the file header with only a `<= 0` check — no upper bound. Past ~715M, `3 * width` overflows the 32-bit multiply and wraps small, so `malloc()` undersizes `lineBuffer` while the unpack loop right below still iterates the original, un-overflowed `width` — reading/writing past the end of it.

Computes the line width in `size_t` instead, so the multiply can't overflow before it reaches `malloc()`.

| CVE | Link |
|---|---|
| CVE-2020-22524 | https://nvd.nist.gov/vuln/detail/CVE-2020-22524 |

Fixes: CVE-2020-22524
