### PR TITLE
Fix BMP RLE8 loader rejecting legitimate files (issue #23)

### DIFF
--- a/Source/FreeImage/PluginBMP.cpp
+++ b/Source/FreeImage/PluginBMP.cpp
@@ -431,8 +431,16 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 	BYTE delta_y = 0;
 
 	height = abs(height);
-	
-	while(scanline < height) {
+
+	// NB: this loop is intentionally not bounded by `scanline < height` - a
+	// well-formed RLE8 stream can (and often does) emit a trailing
+	// RLE_ENDOFBITMAP marker only after `scanline` has already reached
+	// `height` (e.g. right after the final RLE_ENDOFLINE), and bounding the
+	// loop on `scanline` prevents ever reading that marker, causing this
+	// function to spuriously fail on legitimate files (see issue #23).
+	// Safety against out-of-bounds writes (CVE-2020-21427) is instead
+	// enforced directly at each FreeImage_GetScanLine() call site below.
+	for (;;) {
 
 		if (io->read_proc(&status_byte, sizeof(BYTE), 1, handle) != 1) {
 			return FALSE;
@@ -469,6 +477,9 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 
 				default:
 					// absolute mode
+					if (scanline >= height) {
+						return FALSE;
+					}
 					count = MIN((int)status_byte, width - bits);
 					if (count < 0) {
 						return FALSE;
@@ -489,6 +500,9 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 			} // switch (status_byte)
 		}
 		else {
+			if (scanline >= height) {
+				return FALSE;
+			}
 			count = MIN((int)status_byte, width - bits);
 			if (count < 0) {
 				return FALSE;


### PR DESCRIPTION
## Problem

SVN r1832's fix for CVE-2020-21427 bounded `LoadPixelDataRLE8`'s decode loop with `while(scanline < height)`. As a side effect, this stops the loop before it can ever read a legitimate trailing `RLE_ENDOFBITMAP` marker once all real scanlines have already been decoded — so well-formed 8-bit RLE BMP files that end with that terminator now fail to load with `FreeImage_Load` returning `NULL`.

Reported in #23, reproduced against the reporter's own sample file.

## Fix

Run the decode loop unconditionally instead of bounding it on `scanline < height`, so it can keep reading past the last real scanline to consume the terminator. The CVE-2020-21427 out-of-bounds-write protection is preserved by checking `scanline >= height` directly at each of the two `FreeImage_GetScanLine()` call sites (the only places that write pixel data), rather than relying on the loop condition.

## Testing

- Reporter's sample file (`image_load_bmp8.bmp`, 3648x2736 8bpp) now loads successfully — previously failed on current master.
- A crafted malicious RLE8 stream encoding 52 scanlines against a declared height of 2 (simulating the original CVE-2020-21427 scenario) still safely fails to load rather than writing out of bounds.