### PR TITLE
Fix PICT and RAS crashes

### DIFF
--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -390,7 +390,8 @@ ReadColorTable( FreeImageIO *io, fi_handle handle, WORD* pNumColors, RGBQUAD* pP
 			// colours in order.
 			val = (WORD)i;
 		}
-		if (val >= numColors) {
+		if (val >= numColors || val >= 256) {
+			// pPal is always a fixed 256-entry array
 			throw "pixel value greater than color table size.";
 		}
 		// Mac colour tables contain 16-bit values for R, G, and B...

--- a/Source/FreeImage/PluginRAS.cpp
+++ b/Source/FreeImage/PluginRAS.cpp
@@ -321,6 +321,10 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 				b = g + numcolors;
 
 				RGBQUAD *pal = FreeImage_GetPalette(dib);
+				if (!pal) {
+					free(r);
+					throw "No palette for bitmap!";
+				}
 
 				io->read_proc(r, 3 * numcolors, 1, handle);
 


### PR DESCRIPTION
Fixes two crashes, both from unapplied SourceForge patches:

- **PICT**: `ReadColorTable()` writes into a fixed 256-entry array but only checked the index against the file's own color count, not against 256. Patch: https://sourceforge.net/p/freeimage/patches/161/
- **RAS**: `FreeImage_GetPalette()` can return NULL for 24bpp+ images, but the RMT_EQUAL_RGB colormap path used it without checking. Patch: https://sourceforge.net/p/freeimage/patches/163/

Tested against the crash files attached to both patches - both segfault on current master, both load safely (clean reject, no crash) with this fix.