### PR TITLE
Bump bundled libjpeg (IJG) to version 10

### DIFF
--- a/Source/LibJPEG/cderror.h
+++ b/Source/LibJPEG/cderror.h
@@ -2,7 +2,7 @@
  * cderror.h
  *
  * Copyright (C) 1994-1997, Thomas G. Lane.
- * Modified 2009-2017 by Guido Vollbeding.
+ * Modified 2009-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -60,6 +60,7 @@ JMESSAGE(JERR_GIF_CODESIZE, "Bogus GIF codesize %d")
 JMESSAGE(JERR_GIF_COLORSPACE, "GIF output must be grayscale or RGB")
 JMESSAGE(JERR_GIF_IMAGENOTFOUND, "Too few images in GIF file")
 JMESSAGE(JERR_GIF_NOT, "Not a GIF file")
+JMESSAGE(JERR_GIF_OUTOFRANGE, "Numeric value out of range in GIF file")
 JMESSAGE(JTRC_GIF, "%ux%ux%d GIF image")
 JMESSAGE(JTRC_GIF_BADVERSION,
 	 "Warning: unexpected GIF version number '%c%c%c'")

--- a/Source/LibJPEG/jcarith.c
+++ b/Source/LibJPEG/jcarith.c
@@ -1,7 +1,7 @@
 /*
  * jcarith.c
  *
- * Developed 1997-2019 by Guido Vollbeding.
+ * Developed 1997-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -361,7 +361,7 @@ emit_restart (j_compress_ptr cinfo, int restart_num)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   unsigned char *st;
@@ -450,7 +450,7 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -557,7 +557,7 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   unsigned char *st;
@@ -592,7 +592,7 @@ encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -691,7 +691,7 @@ encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   const int * natural_order;

--- a/Source/LibJPEG/jccolor.c
+++ b/Source/LibJPEG/jccolor.c
@@ -2,7 +2,7 @@
  * jccolor.c
  *
  * Copyright (C) 1991-1996, Thomas G. Lane.
- * Modified 2011-2019 by Guido Vollbeding.
+ * Modified 2011-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -40,10 +40,10 @@ typedef my_color_converter * my_cconvert_ptr;
  * Note that the derived conversion coefficients given in some of these
  * documents are imprecise.  The general conversion equations are
  *	Y  = Kr * R + (1 - Kr - Kb) * G + Kb * B
- *	Cb = 0.5 * (B - Y) / (1 - Kb)
- *	Cr = 0.5 * (R - Y) / (1 - Kr)
+ *	Cb = (B - Y) / (1 - Kb) / K
+ *	Cr = (R - Y) / (1 - Kr) / K
  * With Kr = 0.299 and Kb = 0.114 (derived according to SMPTE RP 177-1993
- * from the 1953 FCC NTSC primaries and CIE Illuminant C),
+ * from the 1953 FCC NTSC primaries and CIE Illuminant C), K = 2 for sYCC,
  * the conversion equations to be implemented are therefore
  *	Y  =  0.299 * R + 0.587 * G + 0.114 * B
  *	Cb = -0.168735892 * R - 0.331264108 * G + 0.5 * B + CENTERJSAMPLE
@@ -62,8 +62,8 @@ typedef my_color_converter * my_cconvert_ptr;
  * by precalculating the constants times R,G,B for all possible values.
  * For 8-bit JSAMPLEs this is very reasonable (only 256 entries per table);
  * for 9-bit to 12-bit samples it is still acceptable.  It's not very
- * reasonable for 16-bit samples, but if you want lossless storage you
- * shouldn't be changing colorspace anyway.
+ * reasonable for 16-bit samples, but if you want lossless storage
+ * you shouldn't be changing colorspace anyway.
  * The CENTERJSAMPLE offsets and the rounding fudge-factor of 0.5 are included
  * in the tables to save adding them separately in the inner loop.
  */
@@ -110,16 +110,16 @@ rgb_ycc_start (j_compress_ptr cinfo)
   for (i = 0; i <= MAXJSAMPLE; i++) {
     rgb_ycc_tab[i+R_Y_OFF] = FIX(0.299) * i;
     rgb_ycc_tab[i+G_Y_OFF] = FIX(0.587) * i;
-    rgb_ycc_tab[i+B_Y_OFF] = FIX(0.114) * i   + ONE_HALF;
+    rgb_ycc_tab[i+B_Y_OFF] = FIX(0.114) * i + ONE_HALF;
     rgb_ycc_tab[i+R_CB_OFF] = (- FIX(0.168735892)) * i;
     rgb_ycc_tab[i+G_CB_OFF] = (- FIX(0.331264108)) * i;
     /* We use a rounding fudge-factor of 0.5-epsilon for Cb and Cr.
      * This ensures that the maximum output will round to MAXJSAMPLE
      * not MAXJSAMPLE+1, and thus that we don't have to range-limit.
      */
-    rgb_ycc_tab[i+B_CB_OFF] = FIX(0.5) * i    + CBCR_OFFSET + ONE_HALF-1;
+    rgb_ycc_tab[i+B_CB_OFF] = (i << (SCALEBITS-1)) + CBCR_OFFSET + ONE_HALF-1;
 /*  B=>Cb and R=>Cr tables are the same
-    rgb_ycc_tab[i+R_CR_OFF] = FIX(0.5) * i    + CBCR_OFFSET + ONE_HALF-1;
+    rgb_ycc_tab[i+R_CR_OFF] = (i << (SCALEBITS-1)) + CBCR_OFFSET + ONE_HALF-1;
 */
     rgb_ycc_tab[i+G_CR_OFF] = (- FIX(0.418687589)) * i;
     rgb_ycc_tab[i+B_CR_OFF] = (- FIX(0.081312411)) * i;
@@ -190,8 +190,8 @@ rgb_ycc_convert (j_compress_ptr cinfo,
 
 /*
  * Convert some rows of samples to the JPEG colorspace.
- * This version handles RGB->grayscale conversion, which is the same
- * as the RGB->Y portion of RGB->YCbCr.
+ * This version handles RGB->grayscale conversion,
+ * which is the same as the RGB->Y portion of RGB->YCbCr.
  * We assume rgb_ycc_start has been called (we only use the Y tables).
  */
 
@@ -201,7 +201,7 @@ rgb_gray_convert (j_compress_ptr cinfo,
 		  JDIMENSION output_row, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int r, g, b;
+  register INT32 y;
   register INT32 * ctab = cconvert->rgb_ycc_tab;
   register JSAMPROW inptr;
   register JSAMPROW outptr;
@@ -212,14 +212,11 @@ rgb_gray_convert (j_compress_ptr cinfo,
     inptr = *input_buf++;
     outptr = output_buf[0][output_row++];
     for (col = 0; col < num_cols; col++) {
-      r = GETJSAMPLE(inptr[RGB_RED]);
-      g = GETJSAMPLE(inptr[RGB_GREEN]);
-      b = GETJSAMPLE(inptr[RGB_BLUE]);
+      y  = ctab[R_Y_OFF + GETJSAMPLE(inptr[RGB_RED])];
+      y += ctab[G_Y_OFF + GETJSAMPLE(inptr[RGB_GREEN])];
+      y += ctab[B_Y_OFF + GETJSAMPLE(inptr[RGB_BLUE])];
       inptr += RGB_PIXELSIZE;
-      /* Y */
-      outptr[col] = (JSAMPLE)
-		((ctab[r+R_Y_OFF] + ctab[g+G_Y_OFF] + ctab[b+B_Y_OFF])
-		 >> SCALEBITS);
+      outptr[col] = (JSAMPLE) (y >> SCALEBITS);
     }
   }
 }
@@ -479,8 +476,9 @@ jinit_color_converter (j_compress_ptr cinfo)
 
   /* Support color transform only for RGB colorspaces */
   if (cinfo->color_transform &&
-      cinfo->jpeg_color_space != JCS_RGB &&
-      cinfo->jpeg_color_space != JCS_BG_RGB)
+      (cinfo->LSE_maxtrans != MAXJSAMPLE ||
+       (cinfo->jpeg_color_space != JCS_RGB &&
+	cinfo->jpeg_color_space != JCS_BG_RGB)))
     ERREXIT(cinfo, JERR_CONVERSION_NOTIMPL);
 
   /* Check num_components, set conversion method based on requested space */

--- a/Source/LibJPEG/jcdctmgr.c
+++ b/Source/LibJPEG/jcdctmgr.c
@@ -2,7 +2,7 @@
  * jcdctmgr.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
- * Modified 2003-2013 by Guido Vollbeding.
+ * Modified 2003-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -50,31 +50,18 @@ typedef union {
 } divisor_table;
 
 
-/* The current scaled-DCT routines require ISLOW-style divisor tables,
- * so be sure to compile that code if either ISLOW or SCALING is requested.
- */
-#ifdef DCT_ISLOW_SUPPORTED
-#define PROVIDE_ISLOW_TABLES
-#else
-#ifdef DCT_SCALING_SUPPORTED
-#define PROVIDE_ISLOW_TABLES
-#endif
-#endif
-
-
 /*
  * Perform forward DCT on one or more blocks of a component.
  *
  * The input samples are taken from the sample_data[] array starting at
- * position start_row/start_col, and moving to the right for any additional
- * blocks. The quantized coefficients are returned in coef_blocks[].
+ * position start_col, and moving to the right for any additional blocks.
+ * The quantized coefficients are returned in coef_blocks[].
  */
 
 METHODDEF(void)
 forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
 	     JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-	     JDIMENSION start_row, JDIMENSION start_col,
-	     JDIMENSION num_blocks)
+	     JDIMENSION start_col, JDIMENSION num_blocks)
 /* This version is used for integer DCT implementations. */
 {
   /* This routine is heavily used, so it's worth coding it tightly. */
@@ -83,8 +70,6 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
   DCTELEM * divisors = (DCTELEM *) compptr->dct_table;
   DCTELEM workspace[DCTSIZE2];	/* work area for FDCT subroutine */
   JDIMENSION bi;
-
-  sample_data += start_row;	/* fold in the vertical offset once */
 
   for (bi = 0; bi < num_blocks; bi++, start_col += compptr->DCT_h_scaled_size) {
     /* Perform the DCT */
@@ -105,9 +90,9 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
 	 * In most files, at least half of the output values will be zero
 	 * (at default quantization settings, more like three-quarters...)
 	 * so we should ensure that this case is fast.  On many machines,
-	 * a comparison is enough cheaper than a divide to make a special test
-	 * a win.  Since both inputs will be nonnegative, we need only test
-	 * for a < b to discover whether a/b is 0.
+	 * a comparison is enough cheaper than a divide to make a special
+	 * test a win.  Since both inputs will be nonnegative, we need
+	 * only test for a < b to discover whether a/b is 0.
 	 * If your machine's division is fast enough, define FAST_DIVIDE.
 	 */
 #ifdef FAST_DIVIDE
@@ -136,8 +121,7 @@ forward_DCT (j_compress_ptr cinfo, jpeg_component_info * compptr,
 METHODDEF(void)
 forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
 		   JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-		   JDIMENSION start_row, JDIMENSION start_col,
-		   JDIMENSION num_blocks)
+		   JDIMENSION start_col, JDIMENSION num_blocks)
 /* This version is used for floating-point DCT implementations. */
 {
   /* This routine is heavily used, so it's worth coding it tightly. */
@@ -146,8 +130,6 @@ forward_DCT_float (j_compress_ptr cinfo, jpeg_component_info * compptr,
   FAST_FLOAT * divisors = (FAST_FLOAT *) compptr->dct_table;
   FAST_FLOAT workspace[DCTSIZE2]; /* work area for FDCT subroutine */
   JDIMENSION bi;
-
-  sample_data += start_row;	/* fold in the vertical offset once */
 
   for (bi = 0; bi < num_blocks; bi++, start_col += compptr->DCT_h_scaled_size) {
     /* Perform the DCT */
@@ -191,7 +173,7 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
   my_fdct_ptr fdct = (my_fdct_ptr) cinfo->fdct;
   int ci, qtblno, i;
   jpeg_component_info *compptr;
-  int method = 0;
+  J_DCT_METHOD method = JDCT_DEFAULT;
   JQUANT_TBL * qtbl;
   DCTELEM * dtbl;
 
@@ -200,6 +182,13 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
     /* Select the proper DCT routine for this component's scaling */
     switch ((compptr->DCT_h_scaled_size << 8) + compptr->DCT_v_scaled_size) {
 #ifdef DCT_SCALING_SUPPORTED
+/*
+ * The current scaled-DCT routines require ISLOW-style divisor tables,
+ * so be sure to compile that code if either ISLOW or SCALING is requested.
+ */
+#ifndef PROVIDE_ISLOW_TABLES
+#define PROVIDE_ISLOW_TABLES
+#endif
     case ((1 << 8) + 1):
       fdct->do_dct[ci] = jpeg_fdct_1x1;
       method = JDCT_ISLOW;	/* jfdctint uses islow-style table */
@@ -329,14 +318,34 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
       switch (cinfo->dct_method) {
 #ifdef DCT_ISLOW_SUPPORTED
       case JDCT_ISLOW:
+#ifndef PROVIDE_ISLOW_TABLES
+#define PROVIDE_ISLOW_TABLES
+#endif
 	fdct->do_dct[ci] = jpeg_fdct_islow;
 	method = JDCT_ISLOW;
 	break;
 #endif
 #ifdef DCT_IFAST_SUPPORTED
       case JDCT_IFAST:
+#if BITS_IN_JSAMPLE < JPEG_DATA_PRECISION || \
+    BITS_IN_JSAMPLE > JPEG_DATA_PRECISION + 8
+	/*
+	 * Adjustment of divisor tables in JDCT_IFAST
+	 * below doesn't work well in this condition.
+	 * Use JDCT_ISLOW instead.
+	 */
+#ifndef PROVIDE_ISLOW_TABLES
+#define PROVIDE_ISLOW_TABLES
+#endif
+	fdct->do_dct[ci] = jpeg_fdct_islow;
+	method = JDCT_ISLOW;
+#else
+#ifndef PROVIDE_IFAST_TABLES
+#define PROVIDE_IFAST_TABLES
+#endif
 	fdct->do_dct[ci] = jpeg_fdct_ifast;
 	method = JDCT_IFAST;
+#endif
 	break;
 #endif
 #ifdef DCT_FLOAT_SUPPORTED
@@ -347,13 +356,11 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 #endif
       default:
 	ERREXIT(cinfo, JERR_NOT_COMPILED);
-	break;
       }
       break;
     default:
       ERREXIT2(cinfo, JERR_BAD_DCTSIZE,
 	       compptr->DCT_h_scaled_size, compptr->DCT_v_scaled_size);
-      break;
     }
     qtblno = compptr->quant_tbl_no;
     /* Make sure specified quantization table is present */
@@ -365,7 +372,7 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
     switch (method) {
 #ifdef PROVIDE_ISLOW_TABLES
     case JDCT_ISLOW:
-      /* For LL&M IDCT method, divisors are equal to raw quantization
+      /* For LL&M FDCT method, divisors are equal to raw quantization
        * coefficients multiplied by 8 (to counteract scaling).
        */
       dtbl = (DCTELEM *) compptr->dct_table;
@@ -376,14 +383,15 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
       fdct->pub.forward_DCT[ci] = forward_DCT;
       break;
 #endif
-#ifdef DCT_IFAST_SUPPORTED
+#ifdef PROVIDE_IFAST_TABLES
     case JDCT_IFAST:
       {
-	/* For AA&N IDCT method, divisors are equal to quantization
+	/* For AA&N FDCT method, divisors are equal to quantization
 	 * coefficients scaled by scalefactor[row]*scalefactor[col], where
 	 *   scalefactor[0] = 1
 	 *   scalefactor[k] = cos(k*PI/16) * sqrt(2)    for k=1..7
-	 * We apply a further scale factor of 8.
+	 * We apply a further scale factor of 8
+	 * with adjustment if necessary.
 	 */
 #define CONST_BITS 14
 	static const INT16 aanscales[DCTSIZE2] = {
@@ -400,11 +408,20 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 	SHIFT_TEMPS
 
 	dtbl = (DCTELEM *) compptr->dct_table;
-	for (i = 0; i < DCTSIZE2; i++) {
-	  dtbl[i] = (DCTELEM)
-	    DESCALE(MULTIPLY16V16((INT32) qtbl->quantval[i],
-				  (INT32) aanscales[i]),
-		    compptr->component_needed ? CONST_BITS-4 : CONST_BITS-3);
+	if (compptr->component_needed) {
+	  for (i = 0; i < DCTSIZE2; i++) {
+	    dtbl[i] = (DCTELEM)
+	      DESCALE(MULTIPLY16V16((INT32) qtbl->quantval[i],
+				    (INT32) aanscales[i]),
+		      CONST_BITS+JPEG_DATA_PRECISION-BITS_IN_JSAMPLE-4);
+	  }
+	} else {
+	  for (i = 0; i < DCTSIZE2; i++) {
+	    dtbl[i] = (DCTELEM)
+	      DESCALE(MULTIPLY16V16((INT32) qtbl->quantval[i],
+				    (INT32) aanscales[i]),
+		      CONST_BITS+JPEG_DATA_PRECISION-BITS_IN_JSAMPLE-3);
+	  }
 	}
       }
       fdct->pub.forward_DCT[ci] = forward_DCT;
@@ -413,11 +430,12 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 #ifdef DCT_FLOAT_SUPPORTED
     case JDCT_FLOAT:
       {
-	/* For float AA&N IDCT method, divisors are equal to quantization
+	/* For float AA&N FDCT method, divisors are equal to quantization
 	 * coefficients scaled by scalefactor[row]*scalefactor[col], where
 	 *   scalefactor[0] = 1
 	 *   scalefactor[k] = cos(k*PI/16) * sqrt(2)    for k=1..7
-	 * We apply a further scale factor of 8.
+	 * We apply a further scale factor of 8
+	 * with adjustment if necessary.
 	 * What's actually stored is 1/divisor so that the inner loop can
 	 * use a multiplication rather than a division.
 	 */
@@ -427,6 +445,7 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 	  1.0, 1.387039845, 1.306562965, 1.175875602,
 	  1.0, 0.785694958, 0.541196100, 0.275899379
 	};
+#if BITS_IN_JSAMPLE == JPEG_DATA_PRECISION
 
 	i = 0;
 	for (row = 0; row < DCTSIZE; row++) {
@@ -435,6 +454,26 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 	      (1.0 / ((double) qtbl->quantval[i] *
 		      aanscalefactor[row] * aanscalefactor[col] *
 		      (compptr->component_needed ? 16.0 : 8.0)));
+#else
+	double extrafactor = compptr->component_needed ? 16.0 : 8.0;
+
+	/* Adjust extra factor */
+#if BITS_IN_JSAMPLE < JPEG_DATA_PRECISION
+	i = JPEG_DATA_PRECISION - BITS_IN_JSAMPLE;
+	do { extrafactor *= 0.5; } while (--i);
+#else
+	i = BITS_IN_JSAMPLE - JPEG_DATA_PRECISION;
+	do { extrafactor *= 2.0; } while (--i);
+#endif
+
+	i = 0;
+	for (row = 0; row < DCTSIZE; row++) {
+	  for (col = 0; col < DCTSIZE; col++) {
+	    fdtbl[i] = (FAST_FLOAT)
+	      (1.0 / ((double) qtbl->quantval[i] *
+		      aanscalefactor[row] * aanscalefactor[col] *
+		      extrafactor));
+#endif
 	    i++;
 	  }
 	}
@@ -444,7 +483,6 @@ start_pass_fdctmgr (j_compress_ptr cinfo)
 #endif
     default:
       ERREXIT(cinfo, JERR_NOT_COMPILED);
-      break;
     }
   }
 }
@@ -461,17 +499,15 @@ jinit_forward_dct (j_compress_ptr cinfo)
   int ci;
   jpeg_component_info *compptr;
 
-  fdct = (my_fdct_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(my_fdct_controller));
+  fdct = (my_fdct_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_fdct_controller));
   cinfo->fdct = &fdct->pub;
   fdct->pub.start_pass = start_pass_fdctmgr;
 
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
     /* Allocate a divisor table for each component */
-    compptr->dct_table =
-      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				  SIZEOF(divisor_table));
+    compptr->dct_table = (*cinfo->mem->alloc_small)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(divisor_table));
   }
 }

--- a/Source/LibJPEG/jchuff.c
+++ b/Source/LibJPEG/jchuff.c
@@ -2,7 +2,7 @@
  * jchuff.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2006-2019 by Guido Vollbeding.
+ * Modified 2006-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -26,16 +26,10 @@
 
 
 /* The legal range of a DCT coefficient is
- *  -1024 .. +1023  for 8-bit data;
- * -16384 .. +16383 for 12-bit data.
- * Hence the magnitude should always fit in 10 or 14 bits respectively.
+ *  -1024 .. +1023  for 8-bit JPEG data precision;
+ * -16384 .. +16383 for 12-bit JPEG data precision.
+ * Hence the magnitude should always fit in JPEG data precision + 2 bits.
  */
-
-#if BITS_IN_JSAMPLE == 8
-#define MAX_COEF_BITS 10
-#else
-#define MAX_COEF_BITS 14
-#endif
 
 /* Derived data constructed for each Huffman table */
 
@@ -542,11 +536,12 @@ emit_restart_e (huff_entropy_ptr entropy, int restart_num)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int temp, temp2;
   register int nbits;
+  int max_coef_bits;
   int blkn, ci, tbl;
   ISHIFT_TEMPS
 
@@ -557,6 +552,9 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
   if (cinfo->restart_interval)
     if (entropy->restarts_to_go == 0)
       emit_restart_e(entropy, entropy->next_restart_num);
+
+  /* Since we're encoding a difference, the range limit is twice as much. */
+  max_coef_bits = cinfo->data_precision + 3;
 
   /* Encode the MCU data blocks */
   for (blkn = 0; blkn < cinfo->blocks_in_MCU; blkn++) {
@@ -569,12 +567,17 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
     temp = IRIGHT_SHIFT((int) (MCU_data[blkn][0][0]), cinfo->Al);
 
     /* DC differences are figured on the point-transformed values. */
-    temp2 = temp - entropy->saved.last_dc_val[ci];
+    if ((temp2 = temp - entropy->saved.last_dc_val[ci]) == 0) {
+      /* Count/emit the Huffman-coded symbol for the number of bits */
+      emit_dc_symbol(entropy, tbl, 0);
+
+      continue;
+    }
+
     entropy->saved.last_dc_val[ci] = temp;
 
     /* Encode the DC coefficient difference per section G.1.2.1 */
-    temp = temp2;
-    if (temp < 0) {
+    if ((temp = temp2) < 0) {
       temp = -temp;		/* temp is abs value of input */
       /* For a negative input, want temp2 = bitwise complement of abs(input) */
       /* This code assumes we are on a two's complement machine */
@@ -583,14 +586,10 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 
     /* Find the number of bits needed for the magnitude of the coefficient */
     nbits = 0;
-    while (temp) {
-      nbits++;
-      temp >>= 1;
-    }
-    /* Check for out-of-range coefficient values.
-     * Since we're encoding a difference, the range limit is twice as much.
-     */
-    if (nbits > MAX_COEF_BITS+1)
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
+    /* Check for out-of-range coefficient values */
+    if (nbits > max_coef_bits)
       ERREXIT(cinfo, JERR_BAD_DCT_COEF);
 
     /* Count/emit the Huffman-coded symbol for the number of bits */
@@ -598,8 +597,7 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
 
     /* Emit that number of bits of the value, if positive, */
     /* or the complement of its magnitude, if negative. */
-    if (nbits)			/* emit_bits rejects calls with size 0 */
-      emit_bits_e(entropy, (unsigned int) temp2, nbits);
+    emit_bits_e(entropy, (unsigned int) temp2, nbits);
   }
 
   cinfo->dest->next_output_byte = entropy->next_output_byte;
@@ -625,7 +623,7 @@ encode_mcu_DC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -633,7 +631,7 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
   register int temp, temp2;
   register int nbits;
   register int r, k;
-  int Se, Al;
+  int Se, Al, max_coef_bits;
 
   entropy->next_output_byte = cinfo->dest->next_output_byte;
   entropy->free_in_buffer = cinfo->dest->free_in_buffer;
@@ -646,6 +644,7 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
   Se = cinfo->Se;
   Al = cinfo->Al;
   natural_order = cinfo->natural_order;
+  max_coef_bits = cinfo->data_precision + 2;
 
   /* Encode the MCU data block */
   block = MCU_data[0];
@@ -666,17 +665,22 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
      */
     if (temp < 0) {
       temp = -temp;		/* temp is abs value of input */
-      temp >>= Al;		/* apply the point transform */
+      /* Apply the point transform, and watch out for case */
+      /* that nonzero coef is zero after point transform. */
+      if ((temp >>= Al) == 0) {
+	r++;
+	continue;
+      }
       /* For a negative coef, want temp2 = bitwise complement of abs(coef) */
       temp2 = ~temp;
     } else {
-      temp >>= Al;		/* apply the point transform */
+      /* Apply the point transform, and watch out for case */
+      /* that nonzero coef is zero after point transform. */
+      if ((temp >>= Al) == 0) {
+	r++;
+	continue;
+      }
       temp2 = temp;
-    }
-    /* Watch out for case that nonzero coef is zero after point transform */
-    if (temp == 0) {
-      r++;
-      continue;
     }
 
     /* Emit any pending EOBRUN */
@@ -689,11 +693,11 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
     }
 
     /* Find the number of bits needed for the magnitude of the coefficient */
-    nbits = 1;			/* there must be at least one 1 bit */
-    while ((temp >>= 1))
-      nbits++;
+    nbits = 0;
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
     /* Check for out-of-range coefficient values */
-    if (nbits > MAX_COEF_BITS)
+    if (nbits > max_coef_bits)
       ERREXIT(cinfo, JERR_BAD_DCT_COEF);
 
     /* Count/emit Huffman symbol for run length / number of bits */
@@ -736,7 +740,7 @@ encode_mcu_AC_first (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int Al, blkn;
@@ -779,7 +783,7 @@ encode_mcu_DC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_AC_refine (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -916,83 +920,89 @@ encode_one_block (working_state * state, JCOEFPTR block, int last_dc_val,
   register int nbits;
   register int r, k;
   int Se = state->cinfo->lim_Se;
+  int max_coef_bits = state->cinfo->data_precision + 3;
   const int * natural_order = state->cinfo->natural_order;
 
   /* Encode the DC coefficient difference per section F.1.2.1 */
 
-  temp = temp2 = block[0] - last_dc_val;
+  if ((temp = block[0] - last_dc_val) == 0) {
+    /* Emit the Huffman-coded symbol for the number of bits */
+    if (! emit_bits_s(state, dctbl->ehufco[0], dctbl->ehufsi[0]))
+      return FALSE;
+  } else {
+    if ((temp2 = temp) < 0) {
+      temp = -temp;		/* temp is abs value of input */
+      /* For a negative input, want temp2 = bitwise complement of abs(input) */
+      /* This code assumes we are on a two's complement machine */
+      temp2--;
+    }
 
-  if (temp < 0) {
-    temp = -temp;		/* temp is abs value of input */
-    /* For a negative input, want temp2 = bitwise complement of abs(input) */
-    /* This code assumes we are on a two's complement machine */
-    temp2--;
-  }
+    /* Find the number of bits needed for the magnitude of the coefficient */
+    nbits = 0;
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
+    /* Check for out-of-range coefficient values.
+     * Since we're encoding a difference, the range limit is twice as much.
+     */
+    if (nbits > max_coef_bits)
+      ERREXIT(state->cinfo, JERR_BAD_DCT_COEF);
 
-  /* Find the number of bits needed for the magnitude of the coefficient */
-  nbits = 0;
-  while (temp) {
-    nbits++;
-    temp >>= 1;
-  }
-  /* Check for out-of-range coefficient values.
-   * Since we're encoding a difference, the range limit is twice as much.
-   */
-  if (nbits > MAX_COEF_BITS+1)
-    ERREXIT(state->cinfo, JERR_BAD_DCT_COEF);
+    /* Emit the Huffman-coded symbol for the number of bits */
+    if (! emit_bits_s(state, dctbl->ehufco[nbits], dctbl->ehufsi[nbits]))
+      return FALSE;
 
-  /* Emit the Huffman-coded symbol for the number of bits */
-  if (! emit_bits_s(state, dctbl->ehufco[nbits], dctbl->ehufsi[nbits]))
-    return FALSE;
-
-  /* Emit that number of bits of the value, if positive, */
-  /* or the complement of its magnitude, if negative. */
-  if (nbits)			/* emit_bits rejects calls with size 0 */
+    /* Emit that number of bits of the value, if positive, */
+    /* or the complement of its magnitude, if negative. */
     if (! emit_bits_s(state, (unsigned int) temp2, nbits))
       return FALSE;
+  }
 
   /* Encode the AC coefficients per section F.1.2.2 */
 
   r = 0;			/* r = run length of zeros */
 
   for (k = 1; k <= Se; k++) {
-    if ((temp2 = block[natural_order[k]]) == 0) {
+    if ((temp = block[natural_order[k]]) == 0) {
       r++;
-    } else {
-      /* if run length > 15, must emit special run-length-16 codes (0xF0) */
-      while (r > 15) {
-	if (! emit_bits_s(state, actbl->ehufco[0xF0], actbl->ehufsi[0xF0]))
-	  return FALSE;
-	r -= 16;
-      }
-
-      temp = temp2;
-      if (temp < 0) {
-	temp = -temp;		/* temp is abs value of input */
-	/* This code assumes we are on a two's complement machine */
-	temp2--;
-      }
-
-      /* Find the number of bits needed for the magnitude of the coefficient */
-      nbits = 1;		/* there must be at least one 1 bit */
-      while ((temp >>= 1))
-	nbits++;
-      /* Check for out-of-range coefficient values */
-      if (nbits > MAX_COEF_BITS)
-	ERREXIT(state->cinfo, JERR_BAD_DCT_COEF);
-
-      /* Emit Huffman symbol for run length / number of bits */
-      temp = (r << 4) + nbits;
-      if (! emit_bits_s(state, actbl->ehufco[temp], actbl->ehufsi[temp]))
-	return FALSE;
-
-      /* Emit that number of bits of the value, if positive, */
-      /* or the complement of its magnitude, if negative. */
-      if (! emit_bits_s(state, (unsigned int) temp2, nbits))
-	return FALSE;
-
-      r = 0;
+      continue;
     }
+
+    /* if run length > 15, must emit special run-length-16 codes (0xF0) */
+    while (r > 15) {
+      if (! emit_bits_s(state, actbl->ehufco[0xF0], actbl->ehufsi[0xF0]))
+	return FALSE;
+      r -= 16;
+    }
+
+    if ((temp2 = temp) < 0) {
+      temp = -temp;		/* temp is abs value of input */
+      /* For a negative coef, want temp2 = bitwise complement of abs(coef) */
+      /* This code assumes we are on a two's complement machine */
+      temp2--;
+    }
+
+    /* Find the number of bits needed for the magnitude of the coefficient */
+    nbits = 0;
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
+    /* Check for out-of-range coefficient values.
+     * Use ">=" instead of ">" so can use the
+     * same one larger limit from DC check here.
+     */
+    if (nbits >= max_coef_bits)
+      ERREXIT(state->cinfo, JERR_BAD_DCT_COEF);
+
+    /* Emit Huffman symbol for run length / number of bits */
+    temp = (r << 4) + nbits;
+    if (! emit_bits_s(state, actbl->ehufco[temp], actbl->ehufsi[temp]))
+      return FALSE;
+
+    /* Emit that number of bits of the value, if positive, */
+    /* or the complement of its magnitude, if negative. */
+    if (! emit_bits_s(state, (unsigned int) temp2, nbits))
+      return FALSE;
+
+    r = 0;			/* reset zero run length */
   }
 
   /* If the last coef(s) were zero, emit an end-of-block code */
@@ -1009,7 +1019,7 @@ encode_one_block (working_state * state, JCOEFPTR block, int last_dc_val,
  */
 
 METHODDEF(boolean)
-encode_mcu_huff (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_huff (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   working_state state;
@@ -1122,28 +1132,31 @@ htest_one_block (j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
   register int nbits;
   register int r, k;
   int Se = cinfo->lim_Se;
+  int max_coef_bits = cinfo->data_precision + 3;
   const int * natural_order = cinfo->natural_order;
 
   /* Encode the DC coefficient difference per section F.1.2.1 */
 
-  temp = block[0] - last_dc_val;
-  if (temp < 0)
-    temp = -temp;
+  if ((temp = block[0] - last_dc_val) == 0) {
+    /* Count the Huffman symbol for the number of bits */
+    dc_counts[0]++;
+  } else {
+    if (temp < 0)
+      temp = -temp;		/* temp is abs value of input */
 
-  /* Find the number of bits needed for the magnitude of the coefficient */
-  nbits = 0;
-  while (temp) {
-    nbits++;
-    temp >>= 1;
+    /* Find the number of bits needed for the magnitude of the coefficient */
+    nbits = 0;
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
+    /* Check for out-of-range coefficient values.
+     * Since we're encoding a difference, the range limit is twice as much.
+     */
+    if (nbits > max_coef_bits)
+      ERREXIT(cinfo, JERR_BAD_DCT_COEF);
+
+    /* Count the Huffman symbol for the number of bits */
+    dc_counts[nbits]++;
   }
-  /* Check for out-of-range coefficient values.
-   * Since we're encoding a difference, the range limit is twice as much.
-   */
-  if (nbits > MAX_COEF_BITS+1)
-    ERREXIT(cinfo, JERR_BAD_DCT_COEF);
-
-  /* Count the Huffman symbol for the number of bits */
-  dc_counts[nbits]++;
 
   /* Encode the AC coefficients per section F.1.2.2 */
 
@@ -1152,30 +1165,33 @@ htest_one_block (j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
   for (k = 1; k <= Se; k++) {
     if ((temp = block[natural_order[k]]) == 0) {
       r++;
-    } else {
-      /* if run length > 15, must emit special run-length-16 codes (0xF0) */
-      while (r > 15) {
-	ac_counts[0xF0]++;
-	r -= 16;
-      }
-
-      /* Find the number of bits needed for the magnitude of the coefficient */
-      if (temp < 0)
-	temp = -temp;
-
-      /* Find the number of bits needed for the magnitude of the coefficient */
-      nbits = 1;		/* there must be at least one 1 bit */
-      while ((temp >>= 1))
-	nbits++;
-      /* Check for out-of-range coefficient values */
-      if (nbits > MAX_COEF_BITS)
-	ERREXIT(cinfo, JERR_BAD_DCT_COEF);
-
-      /* Count Huffman symbol for run length / number of bits */
-      ac_counts[(r << 4) + nbits]++;
-
-      r = 0;
+      continue;
     }
+
+    /* if run length > 15, must emit special run-length-16 codes (0xF0) */
+    while (r > 15) {
+      ac_counts[0xF0]++;
+      r -= 16;
+    }
+
+    if (temp < 0)
+      temp = -temp;		/* temp is abs value of input */
+
+    /* Find the number of bits needed for the magnitude of the coefficient */
+    nbits = 0;
+    do nbits++;			/* there must be at least one 1 bit */
+    while ((temp >>= 1));
+    /* Check for out-of-range coefficient values.
+     * Use ">=" instead of ">" so can use the
+     * same one larger limit from DC check here.
+     */
+    if (nbits >= max_coef_bits)
+      ERREXIT(cinfo, JERR_BAD_DCT_COEF);
+
+    /* Count Huffman symbol for run length / number of bits */
+    ac_counts[(r << 4) + nbits]++;
+
+    r = 0;			/* reset zero run length */
   }
 
   /* If the last coef(s) were zero, emit an end-of-block code */
@@ -1190,7 +1206,7 @@ htest_one_block (j_compress_ptr cinfo, JCOEFPTR block, int last_dc_val,
  */
 
 METHODDEF(boolean)
-encode_mcu_gather (j_compress_ptr cinfo, JBLOCKROW *MCU_data)
+encode_mcu_gather (j_compress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int blkn, ci;

--- a/Source/LibJPEG/jcinit.c
+++ b/Source/LibJPEG/jcinit.c
@@ -2,7 +2,7 @@
  * jcinit.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2003-2017 by Guido Vollbeding.
+ * Modified 2003-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -196,7 +196,7 @@ jinit_compress_master (j_compress_ptr cinfo)
   JDIMENSION jd_samplesperrow;
 
   /* For now, precision must match compiled-in value... */
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision != JPEG_DATA_PRECISION)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   /* Sanity check on input image dimensions */

--- a/Source/LibJPEG/jcmarker.c
+++ b/Source/LibJPEG/jcmarker.c
@@ -2,7 +2,7 @@
  * jcmarker.c
  *
  * Copyright (C) 1991-1998, Thomas G. Lane.
- * Modified 2003-2019 by Guido Vollbeding.
+ * Modified 2003-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -296,7 +296,7 @@ emit_lse_ict (j_compress_ptr cinfo)
   emit_2bytes(cinfo, 24);	/* fixed length */
 
   emit_byte(cinfo, 0x0D);	/* ID inverse transform specification */
-  emit_2bytes(cinfo, MAXJSAMPLE);	/* MAXTRANS */
+  emit_2bytes(cinfo, (int) cinfo->LSE_maxtrans); /* MAXTRANS */
   emit_byte(cinfo, 3);		/* Nt=3 */
   emit_byte(cinfo, cinfo->comp_info[1].component_id);
   emit_byte(cinfo, cinfo->comp_info[0].component_id);

--- a/Source/LibJPEG/jcmaster.c
+++ b/Source/LibJPEG/jcmaster.c
@@ -2,7 +2,7 @@
  * jcmaster.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2003-2019 by Guido Vollbeding.
+ * Modified 2003-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -391,16 +391,16 @@ per_scan_setup (j_compress_ptr cinfo)
 {
   int ci, mcublks, tmp;
   jpeg_component_info *compptr;
-  
+
   if (cinfo->comps_in_scan == 1) {
-    
+
     /* Noninterleaved (single-component) scan */
     compptr = cinfo->cur_comp_info[0];
-    
+
     /* Overall image size in MCUs */
     cinfo->MCUs_per_row = compptr->width_in_blocks;
     cinfo->MCU_rows_in_scan = compptr->height_in_blocks;
-    
+
     /* For noninterleaved scan, always one block per MCU */
     compptr->MCU_width = 1;
     compptr->MCU_height = 1;
@@ -413,28 +413,26 @@ per_scan_setup (j_compress_ptr cinfo)
     tmp = (int) (compptr->height_in_blocks % compptr->v_samp_factor);
     if (tmp == 0) tmp = compptr->v_samp_factor;
     compptr->last_row_height = tmp;
-    
+
     /* Prepare array describing MCU composition */
     cinfo->blocks_in_MCU = 1;
     cinfo->MCU_membership[0] = 0;
-    
+
   } else {
-    
+
     /* Interleaved (multi-component) scan */
     if (cinfo->comps_in_scan <= 0 || cinfo->comps_in_scan > MAX_COMPS_IN_SCAN)
       ERREXIT2(cinfo, JERR_COMPONENT_COUNT, cinfo->comps_in_scan,
 	       MAX_COMPS_IN_SCAN);
-    
+
     /* Overall image size in MCUs */
     cinfo->MCUs_per_row = (JDIMENSION)
       jdiv_round_up((long) cinfo->jpeg_width,
 		    (long) (cinfo->max_h_samp_factor * cinfo->block_size));
-    cinfo->MCU_rows_in_scan = (JDIMENSION)
-      jdiv_round_up((long) cinfo->jpeg_height,
-		    (long) (cinfo->max_v_samp_factor * cinfo->block_size));
-    
+    cinfo->MCU_rows_in_scan = cinfo->total_iMCU_rows;
+
     cinfo->blocks_in_MCU = 0;
-    
+
     for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
       compptr = cinfo->cur_comp_info[ci];
       /* Sampling factors give # of blocks of component in each MCU */
@@ -457,7 +455,7 @@ per_scan_setup (j_compress_ptr cinfo)
 	cinfo->MCU_membership[cinfo->blocks_in_MCU++] = ci;
       }
     }
-    
+
   }
 
   /* Convert restart specified in rows to actual MCU count. */

--- a/Source/LibJPEG/jconfig.h
+++ b/Source/LibJPEG/jconfig.h
@@ -96,6 +96,12 @@
 #ifndef __RPCNDR_H__		/* don't conflict if rpcndr.h already read */
 typedef unsigned char boolean;
 #endif
+#ifndef FALSE			/* in case these macros already exist */
+#define FALSE	0		/* values of boolean */
+#endif
+#ifndef TRUE
+#define TRUE	1
+#endif
 #define HAVE_BOOLEAN		/* prevent jmorecfg.h from redefining it */
 
 /*

--- a/Source/LibJPEG/jcparam.c
+++ b/Source/LibJPEG/jcparam.c
@@ -2,7 +2,7 @@
  * jcparam.c
  *
  * Copyright (C) 1991-1998, Thomas G. Lane.
- * Modified 2003-2019 by Guido Vollbeding.
+ * Modified 2003-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -62,8 +62,9 @@ jpeg_add_quant_table (j_compress_ptr cinfo, int which_tbl,
 
 
 /* These are the sample quantization tables given in JPEG spec section K.1.
- * The spec says that the values given produce "good" quality, and
- * when divided by 2, "very good" quality.
+ * NOTE: chrominance DC value is changed from 17 to 16 for lossless support.
+ * The spec says that the values given produce "good" quality,
+ * and when divided by 2, "very good" quality.
  */
 static const unsigned int std_luminance_quant_tbl[DCTSIZE2] = {
   16,  11,  10,  16,  24,  40,  51,  61,
@@ -76,7 +77,7 @@ static const unsigned int std_luminance_quant_tbl[DCTSIZE2] = {
   72,  92,  95,  98, 112, 100, 103,  99
 };
 static const unsigned int std_chrominance_quant_tbl[DCTSIZE2] = {
-  17,  18,  24,  47,  99,  99,  99,  99,
+  16,  18,  24,  47,  99,  99,  99,  99,
   18,  21,  26,  66,  99,  99,  99,  99,
   24,  26,  56,  99,  99,  99,  99,  99,
   47,  66,  99,  99,  99,  99,  99,  99,
@@ -214,7 +215,7 @@ jpeg_set_defaults (j_compress_ptr cinfo)
 
   cinfo->scale_num = 1;		/* 1:1 scaling */
   cinfo->scale_denom = 1;
-  cinfo->data_precision = BITS_IN_JSAMPLE;
+  cinfo->data_precision = JPEG_DATA_PRECISION;
   /* Set up two quantization tables using default quality of 75 */
   jpeg_set_quality(cinfo, 75, TRUE);
   /* Reset standard Huffman tables */
@@ -282,6 +283,7 @@ jpeg_set_defaults (j_compress_ptr cinfo)
 
   /* No color transform */
   cinfo->color_transform = JCT_NONE;
+  cinfo->LSE_maxtrans = MAXJSAMPLE; /* Default LSE MAXTRANS value */
 
   /* Choose JPEG colorspace based on input space, set defaults accordingly */
 
@@ -379,11 +381,13 @@ jpeg_set_colorspace (j_compress_ptr cinfo, J_COLOR_SPACE colorspace)
   case JCS_RGB:
     cinfo->write_Adobe_marker = TRUE; /* write Adobe marker to flag RGB */
     cinfo->num_components = 3;
-    SET_COMP(0, 0x52 /* 'R' */, 1,1, 0,
+    SET_COMP(0, 0x52 /* 'R' */, 1,1,
+		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     SET_COMP(1, 0x47 /* 'G' */, 1,1, 0, 0,0);
-    SET_COMP(2, 0x42 /* 'B' */, 1,1, 0,
+    SET_COMP(2, 0x42 /* 'B' */, 1,1,
+		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     break;
@@ -417,11 +421,13 @@ jpeg_set_colorspace (j_compress_ptr cinfo, J_COLOR_SPACE colorspace)
     cinfo->JFIF_major_version = 2;   /* Set JFIF major version = 2 */
     cinfo->num_components = 3;
     /* Add offset 0x20 to the normal R/G/B component IDs */
-    SET_COMP(0, 0x72 /* 'r' */, 1,1, 0,
+    SET_COMP(0, 0x72 /* 'r' */, 1,1,
+		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     SET_COMP(1, 0x67 /* 'g' */, 1,1, 0, 0,0);
-    SET_COMP(2, 0x62 /* 'b' */, 1,1, 0,
+    SET_COMP(2, 0x62 /* 'b' */, 1,1,
+		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0,
 		cinfo->color_transform == JCT_SUBTRACT_GREEN ? 1 : 0);
     break;

--- a/Source/LibJPEG/jcsample.c
+++ b/Source/LibJPEG/jcsample.c
@@ -2,6 +2,7 @@
  * jcsample.c
  *
  * Copyright (C) 1991-1996, Thomas G. Lane.
+ * Modified 2003-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -200,7 +201,7 @@ fullsize_downsample (j_compress_ptr cinfo, jpeg_component_info * compptr,
 		     JSAMPARRAY input_data, JSAMPARRAY output_data)
 {
   /* Copy the data */
-  jcopy_sample_rows(input_data, 0, output_data, 0,
+  jcopy_sample_rows(input_data, output_data,
 		    cinfo->max_v_samp_factor, cinfo->image_width);
   /* Edge-expand */
   expand_right_edge(output_data, cinfo->max_v_samp_factor, cinfo->image_width,
@@ -483,10 +484,9 @@ jinit_downsampler (j_compress_ptr cinfo)
   boolean smoothok = TRUE;
   int h_in_group, v_in_group, h_out_group, v_out_group;
 
-  downsample = (my_downsample_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(my_downsampler));
-  cinfo->downsample = (struct jpeg_downsampler *) downsample;
+  downsample = (my_downsample_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_downsampler));
+  cinfo->downsample = &downsample->pub;
   downsample->pub.start_pass = start_pass_downsample;
   downsample->pub.downsample = sep_downsample;
   downsample->pub.need_context_rows = FALSE;

--- a/Source/LibJPEG/jctrans.c
+++ b/Source/LibJPEG/jctrans.c
@@ -2,7 +2,7 @@
  * jctrans.c
  *
  * Copyright (C) 1995-1998, Thomas G. Lane.
- * Modified 2000-2017 by Guido Vollbeding.
+ * Modified 2000-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -91,6 +91,7 @@ jpeg_copy_critical_parameters (j_decompress_ptr srcinfo,
    * entropy coding mode dependent on image data precision.
    */
   dstinfo->color_transform = srcinfo->color_transform;
+  dstinfo->LSE_maxtrans = srcinfo->LSE_maxtrans;
   jpeg_set_colorspace(dstinfo, srcinfo->jpeg_color_space);
   dstinfo->data_precision = srcinfo->data_precision;
   dstinfo->arith_code = srcinfo->data_precision > 8 ? TRUE : FALSE;
@@ -224,7 +225,7 @@ typedef struct {
   struct jpeg_c_coef_controller pub; /* public fields */
 
   JDIMENSION iMCU_row_num;	/* iMCU row # within image */
-  JDIMENSION mcu_ctr;		/* counts MCUs processed in current row */
+  JDIMENSION MCU_ctr;		/* counts MCUs processed in current row */
   int MCU_vert_offset;		/* counts MCU rows within iMCU row */
   int MCU_rows_per_iMCU_row;	/* number of such rows needed */
 
@@ -232,7 +233,7 @@ typedef struct {
   jvirt_barray_ptr * whole_image;
 
   /* Workspace for constructing dummy blocks at right/bottom edges. */
-  JBLOCKROW dummy_buffer[C_MAX_BLOCKS_IN_MCU];
+  JBLOCK dummy_buffer[C_MAX_BLOCKS_IN_MCU];
 } my_coef_controller;
 
 typedef my_coef_controller * my_coef_ptr;
@@ -257,7 +258,7 @@ start_iMCU_row (j_compress_ptr cinfo)
       coef->MCU_rows_per_iMCU_row = cinfo->cur_comp_info[0]->last_row_height;
   }
 
-  coef->mcu_ctr = 0;
+  coef->MCU_ctr = 0;
   coef->MCU_vert_offset = 0;
 }
 
@@ -315,25 +316,30 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
   /* Loop to process one whole iMCU row */
   for (yoffset = coef->MCU_vert_offset; yoffset < coef->MCU_rows_per_iMCU_row;
        yoffset++) {
-    for (MCU_col_num = coef->mcu_ctr; MCU_col_num < cinfo->MCUs_per_row;
+    for (MCU_col_num = coef->MCU_ctr; MCU_col_num <= last_MCU_col;
 	 MCU_col_num++) {
       /* Construct list of pointers to DCT blocks belonging to this MCU */
       blkn = 0;			/* index of current DCT block within MCU */
       for (ci = 0; ci < cinfo->comps_in_scan; ci++) {
 	compptr = cinfo->cur_comp_info[ci];
-	start_col = MCU_col_num * compptr->MCU_width;
 	blockcnt = (MCU_col_num < last_MCU_col) ? compptr->MCU_width
 						: compptr->last_col_width;
+	start_col = MCU_col_num * compptr->MCU_width;
 	for (yindex = 0; yindex < compptr->MCU_height; yindex++) {
 	  if (coef->iMCU_row_num < last_iMCU_row ||
-	      yindex+yoffset < compptr->last_row_height) {
+	      yoffset + yindex < compptr->last_row_height) {
 	    /* Fill in pointers to real blocks in this row */
-	    buffer_ptr = buffer[ci][yindex+yoffset] + start_col;
-	    for (xindex = 0; xindex < blockcnt; xindex++)
+	    buffer_ptr = buffer[ci][yoffset + yindex] + start_col;
+	    xindex = blockcnt;
+	    do {
 	      MCU_buffer[blkn++] = buffer_ptr++;
+	    } while (--xindex);
+	    /* Dummy blocks at right edge */
+	    if ((xindex = compptr->MCU_width - blockcnt) == 0)
+	      continue;
 	  } else {
 	    /* At bottom of image, need a whole row of dummy blocks */
-	    xindex = 0;
+	    xindex = compptr->MCU_width;
 	  }
 	  /* Fill in any dummy blocks needed in this row.
 	   * Dummy blocks are filled in the same way as in jccoefct.c:
@@ -341,23 +347,23 @@ compress_output (j_compress_ptr cinfo, JSAMPIMAGE input_buf)
 	   * block's DC value.  The init routine has already zeroed the
 	   * AC entries, so we need only set the DC entries correctly.
 	   */
-	  for (; xindex < compptr->MCU_width; xindex++) {
-	    MCU_buffer[blkn] = coef->dummy_buffer[blkn];
-	    MCU_buffer[blkn][0][0] = MCU_buffer[blkn-1][0][0];
-	    blkn++;
-	  }
+	  buffer_ptr = coef->dummy_buffer + blkn;
+	  do {
+	    buffer_ptr[0][0] = MCU_buffer[blkn-1][0][0];
+	    MCU_buffer[blkn++] = buffer_ptr++;
+	  } while (--xindex);
 	}
       }
       /* Try to write the MCU. */
       if (! (*cinfo->entropy->encode_mcu) (cinfo, MCU_buffer)) {
 	/* Suspension forced; update state counters and exit */
 	coef->MCU_vert_offset = yoffset;
-	coef->mcu_ctr = MCU_col_num;
+	coef->MCU_ctr = MCU_col_num;
 	return FALSE;
       }
     }
     /* Completed an MCU row, but perhaps not an iMCU row */
-    coef->mcu_ctr = 0;
+    coef->MCU_ctr = 0;
   }
   /* Completed the iMCU row, advance counters for next one */
   coef->iMCU_row_num++;
@@ -379,12 +385,9 @@ transencode_coef_controller (j_compress_ptr cinfo,
 			     jvirt_barray_ptr * coef_arrays)
 {
   my_coef_ptr coef;
-  JBLOCKROW buffer;
-  int i;
 
-  coef = (my_coef_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(my_coef_controller));
+  coef = (my_coef_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_coef_controller));
   cinfo->coef = &coef->pub;
   coef->pub.start_pass = start_pass_coef;
   coef->pub.compress_data = compress_output;
@@ -392,12 +395,6 @@ transencode_coef_controller (j_compress_ptr cinfo,
   /* Save pointer to virtual arrays */
   coef->whole_image = coef_arrays;
 
-  /* Allocate and pre-zero space for dummy DCT blocks. */
-  buffer = (JBLOCKROW)
-    (*cinfo->mem->alloc_large) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				C_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-  FMEMZERO((void FAR *) buffer, C_MAX_BLOCKS_IN_MCU * SIZEOF(JBLOCK));
-  for (i = 0; i < C_MAX_BLOCKS_IN_MCU; i++) {
-    coef->dummy_buffer[i] = buffer + i;
-  }
+  /* Pre-zero space for dummy DCT blocks */
+  MEMZERO(coef->dummy_buffer, SIZEOF(coef->dummy_buffer));
 }

--- a/Source/LibJPEG/jdapimin.c
+++ b/Source/LibJPEG/jdapimin.c
@@ -2,7 +2,7 @@
  * jdapimin.c
  *
  * Copyright (C) 1994-1998, Thomas G. Lane.
- * Modified 2009-2013 by Guido Vollbeding.
+ * Modified 2009-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -114,7 +114,7 @@ jpeg_abort_decompress (j_decompress_ptr cinfo)
 LOCAL(void)
 default_decompress_parms (j_decompress_ptr cinfo)
 {
-  int cid0, cid1, cid2;
+  int cid0, cid1, cid2, cid3;
 
   /* Guess the input colorspace, and set output colorspace accordingly. */
   /* Note application may override our guesses. */
@@ -123,13 +123,16 @@ default_decompress_parms (j_decompress_ptr cinfo)
     cinfo->jpeg_color_space = JCS_GRAYSCALE;
     cinfo->out_color_space = JCS_GRAYSCALE;
     break;
-    
+
   case 3:
     cid0 = cinfo->comp_info[0].component_id;
     cid1 = cinfo->comp_info[1].component_id;
     cid2 = cinfo->comp_info[2].component_id;
 
-    /* First try to guess from the component IDs */
+    /* For robust detection of standard colorspaces
+     * regardless of the presence of special markers,
+     * check component IDs from SOF marker first.
+     */
     if      (cid0 == 0x01 && cid1 == 0x02 && cid2 == 0x03)
       cinfo->jpeg_color_space = JCS_YCbCr;
     else if (cid0 == 0x01 && cid1 == 0x22 && cid2 == 0x23)
@@ -151,7 +154,6 @@ default_decompress_parms (j_decompress_ptr cinfo)
       default:
 	WARNMS1(cinfo, JWRN_ADOBE_XFORM, cinfo->Adobe_transform);
 	cinfo->jpeg_color_space = JCS_YCbCr;	/* assume it's YCbCr */
-	break;
       }
     } else {
       TRACEMS3(cinfo, 1, JTRC_UNKNOWN_IDS, cid0, cid1, cid2);
@@ -160,9 +162,22 @@ default_decompress_parms (j_decompress_ptr cinfo)
     /* Always guess RGB is proper output colorspace. */
     cinfo->out_color_space = JCS_RGB;
     break;
-    
+
   case 4:
-    if (cinfo->saw_Adobe_marker) {
+    cid0 = cinfo->comp_info[0].component_id;
+    cid1 = cinfo->comp_info[1].component_id;
+    cid2 = cinfo->comp_info[2].component_id;
+    cid3 = cinfo->comp_info[3].component_id;
+
+    /* For robust detection of standard colorspaces
+     * regardless of the presence of special markers,
+     * check component IDs from SOF marker first.
+     */
+    if      (cid0 == 0x01 && cid1 == 0x02 && cid2 == 0x03 && cid3 == 0x04)
+      cinfo->jpeg_color_space = JCS_YCCK;
+    else if (cid0 == 0x43 && cid1 == 0x4D && cid2 == 0x59 && cid3 == 0x4B)
+      cinfo->jpeg_color_space = JCS_CMYK;   /* ASCII 'C', 'M', 'Y', 'K' */
+    else if (cinfo->saw_Adobe_marker) {
       switch (cinfo->Adobe_transform) {
       case 0:
 	cinfo->jpeg_color_space = JCS_CMYK;
@@ -173,19 +188,17 @@ default_decompress_parms (j_decompress_ptr cinfo)
       default:
 	WARNMS1(cinfo, JWRN_ADOBE_XFORM, cinfo->Adobe_transform);
 	cinfo->jpeg_color_space = JCS_YCCK;	/* assume it's YCCK */
-	break;
       }
     } else {
-      /* No special markers, assume straight CMYK. */
+      /* Unknown IDs and no special markers, assume straight CMYK. */
       cinfo->jpeg_color_space = JCS_CMYK;
     }
     cinfo->out_color_space = JCS_CMYK;
     break;
-    
+
   default:
     cinfo->jpeg_color_space = JCS_UNKNOWN;
     cinfo->out_color_space = JCS_UNKNOWN;
-    break;
   }
 
   /* Set defaults for other decompression parameters. */

--- a/Source/LibJPEG/jdarith.c
+++ b/Source/LibJPEG/jdarith.c
@@ -1,7 +1,7 @@
 /*
  * jdarith.c
  *
- * Developed 1997-2019 by Guido Vollbeding.
+ * Developed 1997-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -239,7 +239,7 @@ process_restart (j_decompress_ptr cinfo)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   JBLOCKROW block;
@@ -318,7 +318,7 @@ decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   JBLOCKROW block;
@@ -400,7 +400,7 @@ decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   unsigned char *st;
@@ -434,7 +434,7 @@ decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   JBLOCKROW block;
@@ -509,7 +509,7 @@ decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   arith_entropy_ptr entropy = (arith_entropy_ptr) cinfo->entropy;
   jpeg_component_info * compptr;

--- a/Source/LibJPEG/jdatadst.c
+++ b/Source/LibJPEG/jdatadst.c
@@ -2,7 +2,7 @@
  * jdatadst.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
- * Modified 2009-2019 by Guido Vollbeding.
+ * Modified 2009-2022 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -28,16 +28,16 @@ extern void free JPP((void *ptr));
 
 /* Expanded data destination object for stdio output */
 
+#define OUTPUT_BUF_SIZE  4096	/* choose an efficiently fwrite'able size */
+
 typedef struct {
   struct jpeg_destination_mgr pub; /* public fields */
 
   FILE * outfile;		/* target stream */
-  JOCTET * buffer;		/* start of buffer */
+  JOCTET buffer[OUTPUT_BUF_SIZE]; /* output buffer */
 } my_destination_mgr;
 
 typedef my_destination_mgr * my_dest_ptr;
-
-#define OUTPUT_BUF_SIZE  4096	/* choose an efficiently fwrite'able size */
 
 
 /* Expanded data destination object for memory output */
@@ -64,10 +64,6 @@ METHODDEF(void)
 init_destination (j_compress_ptr cinfo)
 {
   my_dest_ptr dest = (my_dest_ptr) cinfo->dest;
-
-  /* Allocate the output buffer --- it will be released when done with image */
-  dest->buffer = (JOCTET *) (*cinfo->mem->alloc_small)
-    ((j_common_ptr) cinfo, JPOOL_IMAGE, OUTPUT_BUF_SIZE * SIZEOF(JOCTET));
 
   dest->pub.next_output_byte = dest->buffer;
   dest->pub.free_in_buffer = OUTPUT_BUF_SIZE;
@@ -187,8 +183,8 @@ term_mem_destination (j_compress_ptr cinfo)
 
 /*
  * Prepare for output to a stdio stream.
- * The caller must have already opened the stream, and is responsible
- * for closing it after finishing compression.
+ * The caller must have already opened the stream,
+ * and is responsible for closing it after finishing compression.
  */
 
 GLOBAL(void)

--- a/Source/LibJPEG/jdcolor.c
+++ b/Source/LibJPEG/jdcolor.c
@@ -2,7 +2,7 @@
  * jdcolor.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2011-2019 by Guido Vollbeding.
+ * Modified 2011-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -32,7 +32,9 @@ typedef struct {
   INT32 * Cb_g_tab;		/* => table for Cb to G conversion */
 
   /* Private state for RGB->Y conversion */
-  INT32 * rgb_y_tab;		/* => table for RGB to Y conversion */
+  INT32 * R_y_tab;		/* => table for R to Y conversion */
+  INT32 * G_y_tab;		/* => table for G to Y conversion */
+  INT32 * B_y_tab;		/* => table for B to Y conversion */
 } my_color_deconverter;
 
 typedef my_color_deconverter * my_cconvert_ptr;
@@ -87,28 +89,16 @@ typedef my_color_deconverter * my_cconvert_ptr;
  * by precalculating the constants times Cb and Cr for all possible values.
  * For 8-bit JSAMPLEs this is very reasonable (only 256 entries per table);
  * for 9-bit to 12-bit samples it is still acceptable.  It's not very
- * reasonable for 16-bit samples, but if you want lossless storage you
- * shouldn't be changing colorspace anyway.
- * The Cr=>R and Cb=>B values can be rounded to integers in advance; the
- * values for the G calculation are left scaled up, since we must add them
- * together before rounding.
+ * reasonable for 16-bit samples, but if you want lossless storage
+ * you shouldn't be changing colorspace anyway.
+ * The Cr=>R and Cb=>B values can be rounded to integers in advance;
+ * the values for the G calculation are left scaled up,
+ * since we must add them together before rounding.
  */
 
 #define SCALEBITS	16	/* speediest right-shift on some machines */
 #define ONE_HALF	((INT32) 1 << (SCALEBITS-1))
 #define FIX(x)		((INT32) ((x) * (1L<<SCALEBITS) + 0.5))
-
-/* We allocate one big table for RGB->Y conversion and divide it up into
- * three parts, instead of doing three alloc_small requests.  This lets us
- * use a single table base address, which can be held in a register in the
- * inner loops on many machines (more than can hold all three addresses,
- * anyway).
- */
-
-#define R_Y_OFF		0			/* offset to R => Y section */
-#define G_Y_OFF		(1*(MAXJSAMPLE+1))	/* offset to G => Y section */
-#define B_Y_OFF		(2*(MAXJSAMPLE+1))	/* etc. */
-#define TABLE_SIZE	(3*(MAXJSAMPLE+1))
 
 
 /*
@@ -249,17 +239,19 @@ LOCAL(void)
 build_rgb_y_table (j_decompress_ptr cinfo)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  INT32 * rgb_y_tab;
   INT32 i;
 
-  /* Allocate and fill in the conversion tables. */
-  cconvert->rgb_y_tab = rgb_y_tab = (INT32 *) (*cinfo->mem->alloc_small)
-    ((j_common_ptr) cinfo, JPOOL_IMAGE, TABLE_SIZE * SIZEOF(INT32));
+  cconvert->R_y_tab = (INT32 *) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, (MAXJSAMPLE+1) * SIZEOF(INT32));
+  cconvert->G_y_tab = (INT32 *) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, (MAXJSAMPLE+1) * SIZEOF(INT32));
+  cconvert->B_y_tab = (INT32 *) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, (MAXJSAMPLE+1) * SIZEOF(INT32));
 
   for (i = 0; i <= MAXJSAMPLE; i++) {
-    rgb_y_tab[i+R_Y_OFF] = FIX(0.299) * i;
-    rgb_y_tab[i+G_Y_OFF] = FIX(0.587) * i;
-    rgb_y_tab[i+B_Y_OFF] = FIX(0.114) * i + ONE_HALF;
+    cconvert->R_y_tab[i] = FIX(0.299) * i;
+    cconvert->G_y_tab[i] = FIX(0.587) * i;
+    cconvert->B_y_tab[i] = FIX(0.114) * i + ONE_HALF;
   }
 }
 
@@ -274,8 +266,10 @@ rgb_gray_convert (j_decompress_ptr cinfo,
 		  JSAMPARRAY output_buf, int num_rows)
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
-  register int r, g, b;
-  register INT32 * ctab = cconvert->rgb_y_tab;
+  register INT32 y;
+  register INT32 * Rytab = cconvert->R_y_tab;
+  register INT32 * Gytab = cconvert->G_y_tab;
+  register INT32 * Bytab = cconvert->B_y_tab;
   register JSAMPROW outptr;
   register JSAMPROW inptr0, inptr1, inptr2;
   register JDIMENSION col;
@@ -288,13 +282,10 @@ rgb_gray_convert (j_decompress_ptr cinfo,
     input_row++;
     outptr = *output_buf++;
     for (col = 0; col < num_cols; col++) {
-      r = GETJSAMPLE(inptr0[col]);
-      g = GETJSAMPLE(inptr1[col]);
-      b = GETJSAMPLE(inptr2[col]);
-      /* Y */
-      outptr[col] = (JSAMPLE)
-		((ctab[r+R_Y_OFF] + ctab[g+G_Y_OFF] + ctab[b+B_Y_OFF])
-		 >> SCALEBITS);
+      y  = Rytab[GETJSAMPLE(inptr0[col])];
+      y += Gytab[GETJSAMPLE(inptr1[col])];
+      y += Bytab[GETJSAMPLE(inptr2[col])];
+      outptr[col] = (JSAMPLE) (y >> SCALEBITS);
     }
   }
 }
@@ -354,7 +345,10 @@ rgb1_gray_convert (j_decompress_ptr cinfo,
 {
   my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
   register int r, g, b;
-  register INT32 * ctab = cconvert->rgb_y_tab;
+  register INT32 y;
+  register INT32 * Rytab = cconvert->R_y_tab;
+  register INT32 * Gytab = cconvert->G_y_tab;
+  register INT32 * Bytab = cconvert->B_y_tab;
   register JSAMPROW outptr;
   register JSAMPROW inptr0, inptr1, inptr2;
   register JDIMENSION col;
@@ -373,12 +367,10 @@ rgb1_gray_convert (j_decompress_ptr cinfo,
       /* Assume that MAXJSAMPLE+1 is a power of 2, so that the MOD
        * (modulo) operator is equivalent to the bitmask operator AND.
        */
-      r = (r + g - CENTERJSAMPLE) & MAXJSAMPLE;
-      b = (b + g - CENTERJSAMPLE) & MAXJSAMPLE;
-      /* Y */
-      outptr[col] = (JSAMPLE)
-		((ctab[r+R_Y_OFF] + ctab[g+G_Y_OFF] + ctab[b+B_Y_OFF])
-		 >> SCALEBITS);
+      y  = Rytab[(r + g - CENTERJSAMPLE) & MAXJSAMPLE];
+      y += Gytab[g];
+      y += Bytab[(b + g - CENTERJSAMPLE) & MAXJSAMPLE];
+      outptr[col] = (JSAMPLE) (y >> SCALEBITS);
     }
   }
 }
@@ -420,7 +412,7 @@ rgb_convert (j_decompress_ptr cinfo,
 /*
  * Color conversion for no colorspace change: just copy the data,
  * converting from separate-planes to interleaved representation.
- * We assume out_color_components == num_components.
+ * Note: Omit uninteresting components in output buffer.
  */
 
 METHODDEF(void)
@@ -431,22 +423,27 @@ null_convert (j_decompress_ptr cinfo,
   register JSAMPROW outptr;
   register JSAMPROW inptr;
   register JDIMENSION count;
-  register int num_comps = cinfo->num_components;
+  register int out_comps = cinfo->out_color_components;
   JDIMENSION num_cols = cinfo->output_width;
+  JSAMPROW startptr;
   int ci;
+  jpeg_component_info *compptr;
 
   while (--num_rows >= 0) {
     /* It seems fastest to make a separate pass for each component. */
-    for (ci = 0; ci < num_comps; ci++) {
+    startptr = *output_buf++;
+    for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+	 ci++, compptr++) {
+      if (! compptr->component_needed)
+	continue;		/* skip uninteresting component */
       inptr = input_buf[ci][input_row];
-      outptr = output_buf[0] + ci;
+      outptr = startptr++;
       for (count = num_cols; count > 0; count--) {
 	*outptr = *inptr++;	/* don't need GETJSAMPLE() here */
-	outptr += num_comps;
+	outptr += out_comps;
       }
     }
     input_row++;
-    output_buf++;
   }
 }
 
@@ -462,7 +459,7 @@ grayscale_convert (j_decompress_ptr cinfo,
 		   JSAMPIMAGE input_buf, JDIMENSION input_row,
 		   JSAMPARRAY output_buf, int num_rows)
 {
-  jcopy_sample_rows(input_buf[0], (int) input_row, output_buf, 0,
+  jcopy_sample_rows(input_buf[0] + input_row, output_buf,
 		    num_rows, cinfo->output_width);
 }
 
@@ -550,6 +547,46 @@ ycck_cmyk_convert (j_decompress_ptr cinfo,
 
 
 /*
+ * Convert CMYK to YK part of YCCK for colorless output.
+ * We assume build_rgb_y_table has been called.
+ */
+
+METHODDEF(void)
+cmyk_yk_convert (j_decompress_ptr cinfo,
+		 JSAMPIMAGE input_buf, JDIMENSION input_row,
+		 JSAMPARRAY output_buf, int num_rows)
+{
+  my_cconvert_ptr cconvert = (my_cconvert_ptr) cinfo->cconvert;
+  register INT32 y;
+  register INT32 * Rytab = cconvert->R_y_tab;
+  register INT32 * Gytab = cconvert->G_y_tab;
+  register INT32 * Bytab = cconvert->B_y_tab;
+  register JSAMPROW outptr;
+  register JSAMPROW inptr0, inptr1, inptr2, inptr3;
+  register JDIMENSION col;
+  JDIMENSION num_cols = cinfo->output_width;
+
+  while (--num_rows >= 0) {
+    inptr0 = input_buf[0][input_row];
+    inptr1 = input_buf[1][input_row];
+    inptr2 = input_buf[2][input_row];
+    inptr3 = input_buf[3][input_row];
+    input_row++;
+    outptr = *output_buf++;
+    for (col = 0; col < num_cols; col++) {
+      y  = Rytab[MAXJSAMPLE - GETJSAMPLE(inptr0[col])];
+      y += Gytab[MAXJSAMPLE - GETJSAMPLE(inptr1[col])];
+      y += Bytab[MAXJSAMPLE - GETJSAMPLE(inptr2[col])];
+      outptr[0] = (JSAMPLE) (y >> SCALEBITS);
+      /* K passes through unchanged */
+      outptr[1] = inptr3[col];	/* don't need GETJSAMPLE here */
+      outptr += 2;
+    }
+  }
+}
+
+
+/*
  * Empty method for start_pass.
  */
 
@@ -568,7 +605,7 @@ GLOBAL(void)
 jinit_color_deconverter (j_decompress_ptr cinfo)
 {
   my_cconvert_ptr cconvert;
-  int ci;
+  int ci, i;
 
   cconvert = (my_cconvert_ptr) (*cinfo->mem->alloc_small)
     ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_color_deconverter));
@@ -603,12 +640,13 @@ jinit_color_deconverter (j_decompress_ptr cinfo)
 
   /* Support color transform only for RGB colorspaces */
   if (cinfo->color_transform &&
-      cinfo->jpeg_color_space != JCS_RGB &&
-      cinfo->jpeg_color_space != JCS_BG_RGB)
+      (cinfo->LSE_maxtrans != MAXJSAMPLE ||
+       (cinfo->jpeg_color_space != JCS_RGB &&
+	cinfo->jpeg_color_space != JCS_BG_RGB)))
     ERREXIT(cinfo, JERR_CONVERSION_NOTIMPL);
 
   /* Set out_color_components and conversion method based on requested space.
-   * Also clear the component_needed flags for any unused components,
+   * Also adjust the component_needed flags for any unused components,
    * so that earlier pipeline stages can avoid useless computation.
    */
 
@@ -674,9 +712,9 @@ jinit_color_deconverter (j_decompress_ptr cinfo)
     break;
 
   case JCS_BG_RGB:
-    cinfo->out_color_components = RGB_PIXELSIZE;
     if (cinfo->jpeg_color_space != JCS_BG_RGB)
       ERREXIT(cinfo, JERR_CONVERSION_NOTIMPL);
+    cinfo->out_color_components = RGB_PIXELSIZE;
     switch (cinfo->color_transform) {
     case JCT_NONE:
       cconvert->pub.color_convert = rgb_convert;
@@ -690,25 +728,38 @@ jinit_color_deconverter (j_decompress_ptr cinfo)
     break;
 
   case JCS_CMYK:
+    if (cinfo->jpeg_color_space != JCS_YCCK)
+      goto def_label;
     cinfo->out_color_components = 4;
-    switch (cinfo->jpeg_color_space) {
-    case JCS_YCCK:
-      cconvert->pub.color_convert = ycck_cmyk_convert;
-      build_ycc_rgb_table(cinfo);
-      break;
-    case JCS_CMYK:
-      cconvert->pub.color_convert = null_convert;
-      break;
-    default:
-      ERREXIT(cinfo, JERR_CONVERSION_NOTIMPL);
-    }
+    cconvert->pub.color_convert = ycck_cmyk_convert;
+    build_ycc_rgb_table(cinfo);
     break;
 
-  default:		/* permit null conversion to same output space */
+  case JCS_YCCK:
+    if (cinfo->jpeg_color_space != JCS_CMYK ||
+	/* Support only YK part of YCCK for colorless output */
+	! cinfo->comp_info[0].component_needed ||
+	  cinfo->comp_info[1].component_needed ||
+	  cinfo->comp_info[2].component_needed ||
+	! cinfo->comp_info[3].component_needed)
+      goto def_label;
+    cinfo->out_color_components = 2;
+    /* Need all components on input side */
+    cinfo->comp_info[1].component_needed = TRUE;
+    cinfo->comp_info[2].component_needed = TRUE;
+    cconvert->pub.color_convert = cmyk_yk_convert;
+    build_rgb_y_table(cinfo);
+    break;
+
+  default: def_label:	/* permit null conversion to same output space */
     if (cinfo->out_color_space != cinfo->jpeg_color_space)
       /* unsupported non-null conversion */
       ERREXIT(cinfo, JERR_CONVERSION_NOTIMPL);
-    cinfo->out_color_components = cinfo->num_components;
+    i = 0;
+    for (ci = 0; ci < cinfo->num_components; ci++)
+      if (cinfo->comp_info[ci].component_needed)
+	i++;		/* count output color components */
+    cinfo->out_color_components = i;
     cconvert->pub.color_convert = null_convert;
   }
 

--- a/Source/LibJPEG/jdct.h
+++ b/Source/LibJPEG/jdct.h
@@ -2,7 +2,7 @@
  * jdct.h
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
- * Modified 2002-2019 by Guido Vollbeding.
+ * Modified 2002-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -17,9 +17,9 @@
 /*
  * A forward DCT routine is given a pointer to an input sample array and
  * a pointer to a work area of type DCTELEM[]; the DCT is to be performed
- * in-place in that buffer.  Type DCTELEM is int for 8-bit samples, INT32
- * for 12-bit samples.  (NOTE: Floating-point DCT implementations use an
- * array of type FAST_FLOAT, instead.)
+ * in-place in that buffer.  Type DCTELEM is int or INT32, depending on
+ * bit depth parameters.  (NOTE: Floating-point DCT implementations use
+ * an array of type FAST_FLOAT, instead.)
  * The input data is to be fetched from the sample array starting at a
  * specified column.  (Any row offset needed will be applied to the array
  * pointer before it is passed to the FDCT code.)
@@ -32,7 +32,20 @@
  * Quantization of the output coefficients is done by jcdctmgr.c.
  */
 
-#if BITS_IN_JSAMPLE == 8
+/* Condition for FDCT:
+ *   BITS_IN_JSAMPLE <= 10 && JPEG_DATA_PRECISION <= 10
+ * Condition for int IDCT where DCTELEM is used (2x2, 1x1, 2x1, 1x2):
+ *   JPEG_DATA_PRECISION + RANGE_BITS <= 12
+ *     [BITS_IN_JSAMPLE - 1 + RANGE_BITS +
+ *       3 - (BITS_IN_JSAMPLE - JPEG_DATA_PRECISION) <= 14]
+ *     {3 - (BITS_IN_JSAMPLE - JPEG_DATA_PRECISION) = PASS2_BITS - PASS1_BITS}
+ * Condition for fast IDCT where DCTELEM is used:
+ *   JPEG_DATA_PRECISION <= 10 && BITS_IN_JSAMPLE <= 13 && RANGE_BITS <= 2
+ *     [BITS_IN_JSAMPLE - 1 + RANGE_BITS + PASS2BITS <= 14]
+ * Combined for all:
+ */
+
+#if BITS_IN_JSAMPLE <= 10 && JPEG_DATA_PRECISION <= 10 && RANGE_BITS <= 2
 typedef int DCTELEM;		/* 16 or 32 bits is fine */
 #else
 typedef INT32 DCTELEM;		/* must have 32 bits */
@@ -64,9 +77,10 @@ typedef JMETHOD(void, float_DCT_method_ptr, (FAST_FLOAT * data,
  */
 
 typedef MULTIPLIER ISLOW_MULT_TYPE; /* short or int, whichever is faster */
-#if BITS_IN_JSAMPLE == 8
+#if JPEG_DATA_PRECISION <= 10 && BITS_IN_JSAMPLE <= 13
 typedef MULTIPLIER IFAST_MULT_TYPE; /* 16 bits is OK, use short if faster */
-#define IFAST_SCALE_BITS  2	/* fractional bits in scale factors */
+#define IFAST_SCALE_BITS  (10 - JPEG_DATA_PRECISION)
+				/* fractional bits in scale factors */
 #else
 typedef INT32 IFAST_MULT_TYPE;	/* need 32 bits for scaled quantizers */
 #define IFAST_SCALE_BITS  13	/* fractional bits in scale factors */
@@ -158,7 +172,7 @@ typedef FAST_FLOAT FLOAT_MULT_TYPE; /* preferred floating type */
 #define jpeg_idct_6x12		jRD6x12
 #define jpeg_idct_5x10		jRD5x10
 #define jpeg_idct_4x8		jRD4x8
-#define jpeg_idct_3x6		jRD3x8
+#define jpeg_idct_3x6		jRD3x6
 #define jpeg_idct_2x4		jRD2x4
 #define jpeg_idct_1x2		jRD1x2
 #endif /* NEED_SHORT_EXTERNAL_NAMES */
@@ -394,7 +408,7 @@ EXTERN(void) jpeg_idct_1x2
 
 #ifdef RIGHT_SHIFT_IS_UNSIGNED
 #define ISHIFT_TEMPS	DCTELEM ishift_temp;
-#if BITS_IN_JSAMPLE == 8
+#if BITS_IN_JSAMPLE <= 10 && JPEG_DATA_PRECISION <= 10 && RANGE_BITS <= 2
 #define DCTELEMBITS  16		/* DCTELEM may be 16 or 32 bits */
 #else
 #define DCTELEMBITS  32		/* DCTELEM must be 32 bits */

--- a/Source/LibJPEG/jdhuff.c
+++ b/Source/LibJPEG/jdhuff.c
@@ -2,7 +2,7 @@
  * jdhuff.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2006-2019 by Guido Vollbeding.
+ * Modified 2006-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -704,7 +704,7 @@ process_restart (j_decompress_ptr cinfo)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int Al = cinfo->Al;
@@ -776,7 +776,7 @@ decode_mcu_DC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int s, k, r;
@@ -864,7 +864,7 @@ decode_mcu_AC_first (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   JCOEF p1;
@@ -913,7 +913,7 @@ decode_mcu_DC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_AC_refine (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   register int s, k, r;
@@ -1072,7 +1072,7 @@ undoit:
  */
 
 METHODDEF(boolean)
-decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   const int * natural_order;
@@ -1201,7 +1201,7 @@ decode_mcu_sub (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
  */
 
 METHODDEF(boolean)
-decode_mcu (j_decompress_ptr cinfo, JBLOCKROW *MCU_data)
+decode_mcu (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data)
 {
   huff_entropy_ptr entropy = (huff_entropy_ptr) cinfo->entropy;
   int blkn;

--- a/Source/LibJPEG/jdmarker.c
+++ b/Source/LibJPEG/jdmarker.c
@@ -2,7 +2,7 @@
  * jdmarker.c
  *
  * Copyright (C) 1991-1998, Thomas G. Lane.
- * Modified 2009-2019 by Guido Vollbeding.
+ * Modified 2009-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -664,7 +664,7 @@ get_lse (j_decompress_ptr cinfo)
   if (tmp != 0x0D)	/* ID inverse transform specification */
     ERREXIT1(cinfo, JERR_UNKNOWN_MARKER, cinfo->unread_marker);
   INPUT_2BYTES(cinfo, tmp, return FALSE);
-  if (tmp != MAXJSAMPLE) goto bad;		/* MAXTRANS */
+  cinfo->LSE_maxtrans = (UINT16) tmp;		/* MAXTRANS */
   INPUT_BYTE(cinfo, tmp, return FALSE);
   if (tmp != 3) goto bad;			/* Nt=3 */
   INPUT_BYTE(cinfo, cid, return FALSE);

--- a/Source/LibJPEG/jdmaster.c
+++ b/Source/LibJPEG/jdmaster.c
@@ -2,7 +2,7 @@
  * jdmaster.c
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 2002-2019 by Guido Vollbeding.
+ * Modified 2002-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -103,10 +103,8 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
  * This function is used for full decompression.
  */
 {
-#ifdef IDCT_SCALING_SUPPORTED
-  int ci, ssize;
+  int ci, i;
   jpeg_component_info *compptr;
-#endif
 
   /* Prevent application from calling me at wrong times */
   if (cinfo->global_state != DSTATE_READY)
@@ -124,7 +122,7 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
    */
   for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
        ci++, compptr++) {
-    ssize = 1;
+    int ssize = 1;
     if (! cinfo->raw_data_out)
       while (cinfo->min_DCT_h_scaled_size * ssize <=
 	     (cinfo->do_fancy_upsampling ? DCTSIZE : DCTSIZE / 2) &&
@@ -166,27 +164,22 @@ jpeg_calc_output_dimensions (j_decompress_ptr cinfo)
 #endif /* IDCT_SCALING_SUPPORTED */
 
   /* Report number of components in selected colorspace. */
-  /* Probably this should be in the color conversion module... */
+  /* This should correspond to the actual code in the color conversion module. */
   switch (cinfo->out_color_space) {
   case JCS_GRAYSCALE:
     cinfo->out_color_components = 1;
     break;
   case JCS_RGB:
   case JCS_BG_RGB:
-#if RGB_PIXELSIZE != 3
     cinfo->out_color_components = RGB_PIXELSIZE;
     break;
-#endif /* else share code with YCbCr */
-  case JCS_YCbCr:
-  case JCS_BG_YCC:
-    cinfo->out_color_components = 3;
-    break;
-  case JCS_CMYK:
-  case JCS_YCCK:
-    cinfo->out_color_components = 4;
-    break;
-  default:			/* else must be same colorspace as in file */
-    cinfo->out_color_components = cinfo->num_components;
+  default:	/* YCCK <=> CMYK conversion or same colorspace as in file */
+    i = 0;
+    for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+	 ci++, compptr++)
+      if (compptr->component_needed)
+	i++;	/* count output color components */
+    cinfo->out_color_components = i;
   }
   cinfo->output_components = (cinfo->quantize_colors ? 1 :
 			      cinfo->out_color_components);
@@ -274,7 +267,7 @@ master_selection (j_decompress_ptr cinfo)
   JDIMENSION jd_samplesperrow;
 
   /* For now, precision must match compiled-in value... */
-  if (cinfo->data_precision != BITS_IN_JSAMPLE)
+  if (cinfo->data_precision != JPEG_DATA_PRECISION)
     ERREXIT1(cinfo, JERR_BAD_PRECISION, cinfo->data_precision);
 
   /* Initialize dimensions and other stuff */

--- a/Source/LibJPEG/jdmerge.c
+++ b/Source/LibJPEG/jdmerge.c
@@ -2,7 +2,7 @@
  * jdmerge.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
- * Modified 2013-2019 by Guido Vollbeding.
+ * Modified 2013-2022 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -20,17 +20,17 @@
  *	B = Y + K4 * Cb
  * only the Y term varies among the group of pixels corresponding to a pair
  * of chroma samples, so the rest of the terms can be calculated just once.
- * At typical sampling ratios, this eliminates half or three-quarters of the
- * multiplications needed for color conversion.
+ * At typical sampling ratios, this eliminates half or three-quarters
+ * of the multiplications needed for color conversion.
  *
  * This file currently provides implementations for the following cases:
  *	YCC => RGB color conversion only (YCbCr or BG_YCC).
  *	Sampling ratios of 2h1v or 2h2v.
  *	No scaling needed at upsample time.
  *	Corner-aligned (non-CCIR601) sampling alignment.
- * Other special cases could be added, but in most applications these are
- * the only common cases.  (For uncommon cases we fall back on the more
- * general code in jdsample.c and jdcolor.c.)
+ * Other special cases could be added, but in most applications these
+ * are the only common cases.  (For uncommon cases we fall back on
+ * the more general code in jdsample.c and jdcolor.c.)
  */
 
 #define JPEG_INTERNALS
@@ -190,7 +190,7 @@ merged_2v_upsample (j_decompress_ptr cinfo,
 
   if (upsample->spare_full) {
     /* If we have a spare row saved from a previous cycle, just return it. */
-    jcopy_sample_rows(& upsample->spare_row, 0, output_buf + *out_row_ctr, 0,
+    jcopy_sample_rows(& upsample->spare_row, output_buf + *out_row_ctr,
 		      1, upsample->out_row_width);
     num_rows = 1;
     upsample->spare_full = FALSE;
@@ -286,9 +286,9 @@ h2v1_merged_upsample (j_decompress_ptr cinfo,
     /* Do the chroma part of the calculation */
     cb = GETJSAMPLE(*inptr1++);
     cr = GETJSAMPLE(*inptr2++);
-    cred   = Crrtab[cr];
     cgreen = (int) RIGHT_SHIFT(Cbgtab[cb] + Crgtab[cr], SCALEBITS);
     cblue  = Cbbtab[cb];
+    cred   = Crrtab[cr];
     /* Fetch 2 Y values and emit 2 pixels */
     y  = GETJSAMPLE(*inptr0++);
     outptr[RGB_RED]   = range_limit[y + cred];
@@ -303,15 +303,14 @@ h2v1_merged_upsample (j_decompress_ptr cinfo,
   }
   /* If image width is odd, do the last output column separately */
   if (cinfo->output_width & 1) {
+    y  = GETJSAMPLE(*inptr0);
     cb = GETJSAMPLE(*inptr1);
     cr = GETJSAMPLE(*inptr2);
-    cred   = Crrtab[cr];
-    cgreen = (int) RIGHT_SHIFT(Cbgtab[cb] + Crgtab[cr], SCALEBITS);
-    cblue  = Cbbtab[cb];
-    y  = GETJSAMPLE(*inptr0);
-    outptr[RGB_RED]   = range_limit[y + cred];
-    outptr[RGB_GREEN] = range_limit[y + cgreen];
-    outptr[RGB_BLUE]  = range_limit[y + cblue];
+    outptr[RGB_RED]   = range_limit[y + Crrtab[cr]];
+    outptr[RGB_GREEN] = range_limit[y +
+			      ((int) RIGHT_SHIFT(Cbgtab[cb] + Crgtab[cr],
+						 SCALEBITS))];
+    outptr[RGB_BLUE]  = range_limit[y + Cbbtab[cb]];
   }
 }
 
@@ -350,9 +349,9 @@ h2v2_merged_upsample (j_decompress_ptr cinfo,
     /* Do the chroma part of the calculation */
     cb = GETJSAMPLE(*inptr1++);
     cr = GETJSAMPLE(*inptr2++);
-    cred   = Crrtab[cr];
     cgreen = (int) RIGHT_SHIFT(Cbgtab[cb] + Crgtab[cr], SCALEBITS);
     cblue  = Cbbtab[cb];
+    cred   = Crrtab[cr];
     /* Fetch 4 Y values and emit 4 pixels */
     y  = GETJSAMPLE(*inptr00++);
     outptr0[RGB_RED]   = range_limit[y + cred];
@@ -379,9 +378,9 @@ h2v2_merged_upsample (j_decompress_ptr cinfo,
   if (cinfo->output_width & 1) {
     cb = GETJSAMPLE(*inptr1);
     cr = GETJSAMPLE(*inptr2);
-    cred   = Crrtab[cr];
     cgreen = (int) RIGHT_SHIFT(Cbgtab[cb] + Crgtab[cr], SCALEBITS);
     cblue  = Cbbtab[cb];
+    cred   = Crrtab[cr];
     y  = GETJSAMPLE(*inptr00);
     outptr0[RGB_RED]   = range_limit[y + cred];
     outptr0[RGB_GREEN] = range_limit[y + cgreen];

--- a/Source/LibJPEG/jerror.c
+++ b/Source/LibJPEG/jerror.c
@@ -2,7 +2,7 @@
  * jerror.c
  *
  * Copyright (C) 1991-1998, Thomas G. Lane.
- * Modified 2012-2015 by Guido Vollbeding.
+ * Modified 2012-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -237,9 +237,18 @@ jpeg_std_error (struct jpeg_error_mgr * err)
   err->format_message = format_message;
   err->reset_error_mgr = reset_error_mgr;
 
+  err->msg_code = 0;		/* may be useful as a flag for "no error" */
+  err->msg_parm.i[0] = 0;	/* initialize 8 int message parameters */
+  err->msg_parm.i[1] = 0;
+  err->msg_parm.i[2] = 0;
+  err->msg_parm.i[3] = 0;
+  err->msg_parm.i[4] = 0;
+  err->msg_parm.i[5] = 0;
+  err->msg_parm.i[6] = 0;
+  err->msg_parm.i[7] = 0;
+
   err->trace_level = 0;		/* default = no tracing */
   err->num_warnings = 0;	/* no warnings emitted yet */
-  err->msg_code = 0;		/* may be useful as a flag for "no error" */
 
   /* Initialize message table pointers */
   err->jpeg_message_table = jpeg_std_message_table;

--- a/Source/LibJPEG/jerror.h
+++ b/Source/LibJPEG/jerror.h
@@ -2,7 +2,7 @@
  * jerror.h
  *
  * Copyright (C) 1994-1997, Thomas G. Lane.
- * Modified 1997-2018 by Guido Vollbeding.
+ * Modified 1997-2026 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -130,7 +130,7 @@ JMESSAGE(JTRC_ADOBE,
 	 "Adobe APP14 marker: version %d, flags 0x%04x 0x%04x, transform %d")
 JMESSAGE(JTRC_APP0, "Unknown APP0 marker (not JFIF), length %u")
 JMESSAGE(JTRC_APP14, "Unknown APP14 marker (not Adobe), length %u")
-JMESSAGE(JTRC_DAC, "Define Arithmetic Table 0x%02x: 0x%02x")
+JMESSAGE(JTRC_DAC, "Define Arithmetic Conditioning 0x%02x: 0x%02x")
 JMESSAGE(JTRC_DHT, "Define Huffman Table 0x%02x")
 JMESSAGE(JTRC_DQT, "Define Quantization Table %d  precision %d")
 JMESSAGE(JTRC_DRI, "Define Restart Interval %u")
@@ -156,7 +156,7 @@ JMESSAGE(JTRC_SMOOTH_NOTIMPL,
 	 "Smoothing not supported with nonstandard sampling ratios")
 JMESSAGE(JTRC_SOF, "Start Of Frame 0x%02x: width=%u, height=%u, components=%d")
 JMESSAGE(JTRC_SOF_COMPONENT, "    Component %d: %dhx%dv q=%d")
-JMESSAGE(JTRC_SOI, "Start of Image")
+JMESSAGE(JTRC_SOI, "Start Of Image")
 JMESSAGE(JTRC_SOS, "Start Of Scan: %d components")
 JMESSAGE(JTRC_SOS_COMPONENT, "    Component %d: dc=%d ac=%d")
 JMESSAGE(JTRC_SOS_PARAMS, "  Ss=%d, Se=%d, Ah=%d, Al=%d")

--- a/Source/LibJPEG/jmorecfg.h
+++ b/Source/LibJPEG/jmorecfg.h
@@ -2,7 +2,7 @@
  * jmorecfg.h
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 1997-2013 by Guido Vollbeding.
+ * Modified 1997-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -12,25 +12,61 @@
  */
 
 
+#define JPEG_DATA_PRECISION  8				/* see table below */
+#define BITS_IN_JSAMPLE      JPEG_DATA_PRECISION	/* see table below */
 /*
- * Define BITS_IN_JSAMPLE as either
- *   8   for 8-bit sample values (the usual setting)
- *   9   for 9-bit sample values
- *   10  for 10-bit sample values
- *   11  for 11-bit sample values
- *   12  for 12-bit sample values
- * Only 8, 9, 10, 11, and 12 bits sample data precision are supported for
- * full-feature DCT processing.  Further depths up to 16-bit may be added
- * later for the lossless modes of operation.
- * Run-time selection and conversion of data precision will be added later
- * and are currently not supported, sorry.
+ * Most useful alternative for "HDR" (High Dynamic Range) application
+ * with backward compatibility for file interchange (see table below;
+ * move comment marks for selection):
+#define BITS_IN_JSAMPLE      10
+ */
+/* For still higher demands (see table below):
+#define BITS_IN_JSAMPLE      11
+ */
+/* or
+#define BITS_IN_JSAMPLE      12
+ */
+
+/*                      |                     BITS_IN_JSAMPLE
+ *  JPEG_DATA_PRECISION |   read / write with full DCT up to lossless operation
+ *                      |                  exceptions see below
+ * -------------------------------------------------------------------------------
+ *     {[_8_]}    |    _8_   <9>   <10>   <11>*  <12>~
+ *      [_9_]     |    <8>   _9_   <10>   <11>   <12>*
+ *     [_10_]     |    <8>   <9>   _10_   <11>   <12>    13 *
+ *      _11_      |    <8>   <9>   <10>   _11_   <12>    13     14 *
+ *      _12_      |    <8>   <9>   <10>   <11>   _12_    13     14     15 *
+ *       13       |     8     9     10     11     12     13     14     15     16 *
+ *
+ * _x_ currently and previously implemented - default configuration
+ * <x> newly implemented
+ * {x} current standard for file interchange - backward compatible
+ * [x] next standard for file interchange - common DCT implementation category
+ *  *  does not support GCC lossless (GCbCr lossless - requires 1 extra bit)
+ *  ~  1 bit precision loss - effective 11 bits precision (lossy)
+ *
+ * Since the DCT coefficients are 3 bits larger than sample values with normal DCT
+ * processing, it is possible to support sample values with up to 3 more bits than
+ * the nominal JPEG data precision parameter by adapted DCT processing with up to
+ * lossless operation.  The generated JPEG files are fully interchangeable for the
+ * same JPEG data precision parameter.  Another BITS_IN_JSAMPLE setting will just
+ * reconstruct an image with corresponding precision.
+ *
+ * A special case for JPEG data precision 8 with 12-bit sample size (4 more bits)
+ * is provided so that all previously available sample formats are now supported
+ * for file interchange with backward compatibility.
+ * If full-feature DCT up to lossless operation with up to 12-bit sample size is
+ * required, it is recommended to select JPEG data precision 10, because it falls
+ * in the same DCT implementation category with 8 and 9 which may be commonly
+ * supported at run-time as the next standard for file interchange.
+ *
+ * Remaining bit depths and variability at run-time may be added later and
+ * are currently not supported, sorry.
  * Exception:  The transcoding part (jpegtran) supports all settings in a
  * single instance, since it operates on the level of DCT coefficients and
  * not sample values.  The DCT coefficients are of the same type (16 bits)
  * in all cases (see below).
  */
-
-#define BITS_IN_JSAMPLE  8	/* use 8, 9, 10, 11, or 12 */
 
 
 /*
@@ -303,7 +339,10 @@ typedef void noreturn_t;
  * Defining HAVE_BOOLEAN before including jpeglib.h should make it work.
  */
 
-#ifdef HAVE_BOOLEAN
+#ifndef HAVE_BOOLEAN
+#if defined FALSE || defined TRUE || defined QGLOBAL_H
+/* Qt3 defines FALSE and TRUE as "const" variables in qglobal.h */
+typedef int boolean;
 #ifndef FALSE			/* in case these macros already exist */
 #define FALSE	0		/* values of boolean */
 #endif
@@ -312,6 +351,7 @@ typedef void noreturn_t;
 #endif
 #else
 typedef enum { FALSE = 0, TRUE = 1 } boolean;
+#endif
 #endif
 
 
@@ -347,8 +387,8 @@ typedef enum { FALSE = 0, TRUE = 1 } boolean;
 
 #define C_ARITH_CODING_SUPPORTED    /* Arithmetic coding back end? */
 #define C_MULTISCAN_FILES_SUPPORTED /* Multiple-scan JPEG files? */
-#define C_PROGRESSIVE_SUPPORTED	    /* Progressive JPEG? (Requires MULTISCAN)*/
-#define DCT_SCALING_SUPPORTED	    /* Input rescaling via DCT? (Requires DCT_ISLOW)*/
+#define C_PROGRESSIVE_SUPPORTED	    /* Progressive JPEG? (Requires MULTISCAN) */
+#define DCT_SCALING_SUPPORTED	/* Input rescaling via DCT? (Requires DCT_ISLOW) */
 #define ENTROPY_OPT_SUPPORTED	    /* Optimization of entropy coding parms? */
 /* Note: if you selected more than 8-bit data precision, it is dangerous to
  * turn off ENTROPY_OPT_SUPPORTED.  The standard Huffman tables are only
@@ -365,8 +405,8 @@ typedef enum { FALSE = 0, TRUE = 1 } boolean;
 
 #define D_ARITH_CODING_SUPPORTED    /* Arithmetic coding back end? */
 #define D_MULTISCAN_FILES_SUPPORTED /* Multiple-scan JPEG files? */
-#define D_PROGRESSIVE_SUPPORTED	    /* Progressive JPEG? (Requires MULTISCAN)*/
-#define IDCT_SCALING_SUPPORTED	    /* Output rescaling via IDCT? (Requires DCT_ISLOW)*/
+#define D_PROGRESSIVE_SUPPORTED	    /* Progressive JPEG? (Requires MULTISCAN) */
+#define IDCT_SCALING_SUPPORTED	/* Output rescaling via IDCT? (Requires DCT_ISLOW) */
 #define SAVE_MARKERS_SUPPORTED	    /* jpeg_save_markers() needed? */
 #define BLOCK_SMOOTHING_SUPPORTED   /* Block smoothing? (Progressive only) */
 #undef  UPSAMPLE_SCALING_SUPPORTED  /* Output rescaling at upsample stage? */
@@ -380,20 +420,31 @@ typedef enum { FALSE = 0, TRUE = 1 } boolean;
 /*
  * Ordering of RGB data in scanlines passed to or from the application.
  * If your application wants to deal with data in the order B,G,R, just
- * change these macros.  You can also deal with formats such as R,G,B,X
- * (one extra byte per pixel) by changing RGB_PIXELSIZE.  Note that changing
- * the offsets will also change the order in which colormap data is organized.
+ * #define JPEG_USE_RGB_CUSTOM in jconfig.h, or define your own custom
+ * order in jconfig.h and #define JPEG_HAVE_RGB_CUSTOM.
+ * You can also deal with formats such as R,G,B,X (one extra byte per pixel)
+ * by changing RGB_PIXELSIZE.
+ * Note that changing the offsets will also change
+ * the order in which colormap data is organized.
  * RESTRICTIONS:
  * 1. The sample applications cjpeg,djpeg do NOT support modified RGB formats.
  * 2. The color quantizer modules will not behave desirably if RGB_PIXELSIZE
- *    is not 3 (they don't understand about dummy color components!).  So you
- *    can't use color quantization if you change that value.
+ *    is not 3 (they don't understand about dummy color components!).
+ *    So you can't use color quantization if you change that value.
  */
 
+#ifndef JPEG_HAVE_RGB_CUSTOM
+#ifdef JPEG_USE_RGB_CUSTOM
+#define RGB_RED		2	/* Offset of Red in an RGB scanline element */
+#define RGB_GREEN	1	/* Offset of Green */
+#define RGB_BLUE	0	/* Offset of Blue */
+#else
 #define RGB_RED		0	/* Offset of Red in an RGB scanline element */
 #define RGB_GREEN	1	/* Offset of Green */
 #define RGB_BLUE	2	/* Offset of Blue */
+#endif
 #define RGB_PIXELSIZE	3	/* JSAMPLEs per RGB scanline element */
+#endif
 
 
 /* Definitions for speed-related optimizations. */

--- a/Source/LibJPEG/jpegint.h
+++ b/Source/LibJPEG/jpegint.h
@@ -2,7 +2,7 @@
  * jpegint.h
  *
  * Copyright (C) 1991-1997, Thomas G. Lane.
- * Modified 1997-2019 by Guido Vollbeding.
+ * Modified 1997-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -103,8 +103,7 @@ struct jpeg_downsampler {
 typedef JMETHOD(void, forward_DCT_ptr,
 		(j_compress_ptr cinfo, jpeg_component_info * compptr,
 		 JSAMPARRAY sample_data, JBLOCKROW coef_blocks,
-		 JDIMENSION start_row, JDIMENSION start_col,
-		 JDIMENSION num_blocks));
+		 JDIMENSION start_col, JDIMENSION num_blocks));
 
 struct jpeg_forward_dct {
   JMETHOD(void, start_pass, (j_compress_ptr cinfo));
@@ -115,7 +114,7 @@ struct jpeg_forward_dct {
 /* Entropy encoding */
 struct jpeg_entropy_encoder {
   JMETHOD(void, start_pass, (j_compress_ptr cinfo, boolean gather_statistics));
-  JMETHOD(boolean, encode_mcu, (j_compress_ptr cinfo, JBLOCKROW *MCU_data));
+  JMETHOD(boolean, encode_mcu, (j_compress_ptr cinfo, JBLOCKARRAY MCU_data));
   JMETHOD(void, finish_pass, (j_compress_ptr cinfo));
 };
 
@@ -211,7 +210,7 @@ struct jpeg_marker_reader {
 /* Entropy decoding */
 struct jpeg_entropy_decoder {
   JMETHOD(void, start_pass, (j_decompress_ptr cinfo));
-  JMETHOD(boolean, decode_mcu, (j_decompress_ptr cinfo, JBLOCKROW *MCU_data));
+  JMETHOD(boolean, decode_mcu, (j_decompress_ptr cinfo, JBLOCKARRAY MCU_data));
   JMETHOD(void, finish_pass, (j_decompress_ptr cinfo));
 };
 
@@ -416,8 +415,8 @@ EXTERN(void) jinit_memory_mgr JPP((j_common_ptr cinfo));
 /* Utility routines in jutils.c */
 EXTERN(long) jdiv_round_up JPP((long a, long b));
 EXTERN(long) jround_up JPP((long a, long b));
-EXTERN(void) jcopy_sample_rows JPP((JSAMPARRAY input_array, int source_row,
-				    JSAMPARRAY output_array, int dest_row,
+EXTERN(void) jcopy_sample_rows JPP((JSAMPARRAY input_array,
+				    JSAMPARRAY output_array,
 				    int num_rows, JDIMENSION num_cols));
 EXTERN(void) jcopy_block_row JPP((JBLOCKROW input_row, JBLOCKROW output_row,
 				  JDIMENSION num_blocks));

--- a/Source/LibJPEG/jpeglib.h
+++ b/Source/LibJPEG/jpeglib.h
@@ -2,7 +2,7 @@
  * jpeglib.h
  *
  * Copyright (C) 1991-1998, Thomas G. Lane.
- * Modified 2002-2019 by Guido Vollbeding.
+ * Modified 2002-2025 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -34,12 +34,12 @@ extern "C" {
 #endif
 
 /* Version IDs for the JPEG library.
- * Might be useful for tests like "#if JPEG_LIB_VERSION >= 90".
+ * Might be useful for tests like "#if JPEG_LIB_VERSION >= 100".
  */
 
-#define JPEG_LIB_VERSION        90	/* Compatibility version 9.0 */
-#define JPEG_LIB_VERSION_MAJOR  9
-#define JPEG_LIB_VERSION_MINOR  4
+#define JPEG_LIB_VERSION        100	/* Compatibility version 10.0 */
+#define JPEG_LIB_VERSION_MAJOR  10
+#define JPEG_LIB_VERSION_MINOR  0
 
 
 /* Various constants determining the sizes of things.
@@ -384,8 +384,9 @@ struct jpeg_compress_struct {
   UINT16 Y_density;		/* Vertical pixel density */
   boolean write_Adobe_marker;	/* should an Adobe marker be written? */
 
-  J_COLOR_TRANSFORM color_transform;
   /* Color transform identifier, writes LSE marker if nonzero */
+  J_COLOR_TRANSFORM color_transform;
+  UINT16 LSE_maxtrans;		/* LSE MAXTRANS value, usually = MAXJSAMPLE */
 
   /* State variable: index of next scanline to be written to
    * jpeg_write_scanlines().  Application may use this to control its
@@ -606,8 +607,9 @@ struct jpeg_decompress_struct {
   boolean saw_Adobe_marker;	/* TRUE iff an Adobe APP14 marker was found */
   UINT8 Adobe_transform;	/* Color transform code from Adobe marker */
 
-  J_COLOR_TRANSFORM color_transform;
   /* Color transform identifier derived from LSE marker, otherwise zero */
+  J_COLOR_TRANSFORM color_transform;
+  UINT16 LSE_maxtrans;		/* LSE MAXTRANS value, usually = MAXJSAMPLE */
 
   boolean CCIR601_sampling;	/* TRUE=first samples are cosited */
 

--- a/Source/LibJPEG/jquant1.c
+++ b/Source/LibJPEG/jquant1.c
@@ -2,7 +2,7 @@
  * jquant1.c
  *
  * Copyright (C) 1991-1996, Thomas G. Lane.
- * Modified 2011 by Guido Vollbeding.
+ * Modified 2011-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -293,8 +293,7 @@ create_colormap (j_decompress_ptr cinfo)
   /* The colors are ordered in the map in standard row-major order, */
   /* i.e. rightmost (highest-indexed) color changes most rapidly. */
 
-  colormap = (*cinfo->mem->alloc_sarray)
-    ((j_common_ptr) cinfo, JPOOL_IMAGE,
+  colormap = (*cinfo->mem->alloc_sarray) ((j_common_ptr) cinfo, JPOOL_IMAGE,
      (JDIMENSION) total_colors, (JDIMENSION) cinfo->out_color_components);
 
   /* blksize is number of adjacent repeated entries for a component */
@@ -400,9 +399,8 @@ make_odither_array (j_decompress_ptr cinfo, int ncolors)
   int j,k;
   INT32 num,den;
 
-  odither = (ODITHER_MATRIX_PTR)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(ODITHER_MATRIX));
+  odither = (ODITHER_MATRIX_PTR) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(ODITHER_MATRIX));
   /* The inter-value distance for this color is MAXJSAMPLE/(ncolors-1).
    * Hence the dither value for the matrix cell with fill order f
    * (f=0..N-1) should be (N-1-2*f)/(2*N) * MAXJSAMPLE/(ncolors-1).
@@ -531,8 +529,7 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
-    FMEMZERO((void FAR *) output_buf[row],
-	     (size_t) (width * SIZEOF(JSAMPLE)));
+    FMEMZERO((void FAR *) output_buf[row], (size_t) width * SIZEOF(JSAMPLE));
     row_index = cquantize->row_index;
     for (ci = 0; ci < nc; ci++) {
       input_ptr = input_buf[row] + ci;
@@ -636,8 +633,7 @@ quantize_fs_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
 
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
-    FMEMZERO((void FAR *) output_buf[row],
-	     (size_t) (width * SIZEOF(JSAMPLE)));
+    FMEMZERO((void FAR *) output_buf[row], (size_t) width * SIZEOF(JSAMPLE));
     for (ci = 0; ci < nc; ci++) {
       input_ptr = input_buf[row] + ci;
       output_ptr = output_buf[row];
@@ -726,10 +722,10 @@ alloc_fs_workspace (j_decompress_ptr cinfo)
   size_t arraysize;
   int i;
 
-  arraysize = (size_t) ((cinfo->output_width + 2) * SIZEOF(FSERROR));
+  arraysize = ((size_t) cinfo->output_width + (size_t) 2) * SIZEOF(FSERROR);
   for (i = 0; i < cinfo->out_color_components; i++) {
-    cquantize->fserrors[i] = (FSERRPTR)
-      (*cinfo->mem->alloc_large)((j_common_ptr) cinfo, JPOOL_IMAGE, arraysize);
+    cquantize->fserrors[i] = (FSERRPTR) (*cinfo->mem->alloc_large)
+      ((j_common_ptr) cinfo, JPOOL_IMAGE, arraysize);
   }
 }
 
@@ -780,13 +776,12 @@ start_pass_1_quant (j_decompress_ptr cinfo, boolean is_pre_scan)
     if (cquantize->fserrors[0] == NULL)
       alloc_fs_workspace(cinfo);
     /* Initialize the propagated errors to zero. */
-    arraysize = (size_t) ((cinfo->output_width + 2) * SIZEOF(FSERROR));
+    arraysize = ((size_t) cinfo->output_width + (size_t) 2) * SIZEOF(FSERROR);
     for (i = 0; i < cinfo->out_color_components; i++)
       FMEMZERO((void FAR *) cquantize->fserrors[i], arraysize);
     break;
   default:
     ERREXIT(cinfo, JERR_NOT_COMPILED);
-    break;
   }
 }
 
@@ -823,10 +818,9 @@ jinit_1pass_quantizer (j_decompress_ptr cinfo)
 {
   my_cquantize_ptr cquantize;
 
-  cquantize = (my_cquantize_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(my_cquantizer));
-  cinfo->cquantize = (struct jpeg_color_quantizer *) cquantize;
+  cquantize = (my_cquantize_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_cquantizer));
+  cinfo->cquantize = &cquantize->pub;
   cquantize->pub.start_pass = start_pass_1_quant;
   cquantize->pub.finish_pass = finish_pass_1_quant;
   cquantize->pub.new_color_map = new_color_map_1_quant;

--- a/Source/LibJPEG/jquant2.c
+++ b/Source/LibJPEG/jquant2.c
@@ -2,7 +2,7 @@
  * jquant2.c
  *
  * Copyright (C) 1991-1996, Thomas G. Lane.
- * Modified 2011 by Guido Vollbeding.
+ * Modified 2011-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -1197,8 +1197,8 @@ start_pass_2_quant (j_decompress_ptr cinfo, boolean is_pre_scan)
       ERREXIT1(cinfo, JERR_QUANT_MANY_COLORS, MAXNUMCOLORS);
 
     if (cinfo->dither_mode == JDITHER_FS) {
-      size_t arraysize = (size_t) ((cinfo->output_width + 2) *
-				   (3 * SIZEOF(FSERROR)));
+      size_t arraysize = ((size_t) cinfo->output_width + (size_t) 2)
+	* (3 * SIZEOF(FSERROR));
       /* Allocate Floyd-Steinberg workspace if we didn't already. */
       if (cquantize->fserrors == NULL)
 	cquantize->fserrors = (FSERRPTR) (*cinfo->mem->alloc_large)
@@ -1247,10 +1247,9 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   my_cquantize_ptr cquantize;
   int i;
 
-  cquantize = (my_cquantize_ptr)
-    (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_IMAGE,
-				SIZEOF(my_cquantizer));
-  cinfo->cquantize = (struct jpeg_color_quantizer *) cquantize;
+  cquantize = (my_cquantize_ptr) (*cinfo->mem->alloc_small)
+    ((j_common_ptr) cinfo, JPOOL_IMAGE, SIZEOF(my_cquantizer));
+  cinfo->cquantize = &cquantize->pub;
   cquantize->pub.start_pass = start_pass_2_quant;
   cquantize->pub.new_color_map = new_color_map_2_quant;
   cquantize->fserrors = NULL;	/* flag optional arrays not allocated */
@@ -1284,7 +1283,8 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
     if (desired > MAXNUMCOLORS)
       ERREXIT1(cinfo, JERR_QUANT_MANY_COLORS, MAXNUMCOLORS);
     cquantize->sv_colormap = (*cinfo->mem->alloc_sarray)
-      ((j_common_ptr) cinfo,JPOOL_IMAGE, (JDIMENSION) desired, (JDIMENSION) 3);
+      ((j_common_ptr) cinfo, JPOOL_IMAGE,
+       (JDIMENSION) desired, (JDIMENSION) 3);
     cquantize->desired = desired;
   } else
     cquantize->sv_colormap = NULL;
@@ -1302,7 +1302,7 @@ jinit_2pass_quantizer (j_decompress_ptr cinfo)
   if (cinfo->dither_mode == JDITHER_FS) {
     cquantize->fserrors = (FSERRPTR) (*cinfo->mem->alloc_large)
       ((j_common_ptr) cinfo, JPOOL_IMAGE,
-       (size_t) ((cinfo->output_width + 2) * (3 * SIZEOF(FSERROR))));
+       ((size_t) cinfo->output_width + (size_t) 2) * (3 * SIZEOF(FSERROR)));
     /* Might as well create the error-limiting table too. */
     init_error_limit(cinfo);
   }

--- a/Source/LibJPEG/jutils.c
+++ b/Source/LibJPEG/jutils.c
@@ -2,7 +2,7 @@
  * jutils.c
  *
  * Copyright (C) 1991-1996, Thomas G. Lane.
- * Modified 2009-2019 by Guido Vollbeding.
+ * Modified 2009-2020 by Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -52,67 +52,67 @@ const int jpeg_zigzag_order[DCTSIZE2] = {
  */
 
 const int jpeg_natural_order[DCTSIZE2+16] = {
-  0,  1,  8, 16,  9,  2,  3, 10,
- 17, 24, 32, 25, 18, 11,  4,  5,
- 12, 19, 26, 33, 40, 48, 41, 34,
- 27, 20, 13,  6,  7, 14, 21, 28,
- 35, 42, 49, 56, 57, 50, 43, 36,
- 29, 22, 15, 23, 30, 37, 44, 51,
- 58, 59, 52, 45, 38, 31, 39, 46,
- 53, 60, 61, 54, 47, 55, 62, 63,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4,  5,
+  12, 19, 26, 33, 40, 48, 41, 34,
+  27, 20, 13,  6,  7, 14, 21, 28,
+  35, 42, 49, 56, 57, 50, 43, 36,
+  29, 22, 15, 23, 30, 37, 44, 51,
+  58, 59, 52, 45, 38, 31, 39, 46,
+  53, 60, 61, 54, 47, 55, 62, 63,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order7[7*7+16] = {
-  0,  1,  8, 16,  9,  2,  3, 10,
- 17, 24, 32, 25, 18, 11,  4,  5,
- 12, 19, 26, 33, 40, 48, 41, 34,
- 27, 20, 13,  6, 14, 21, 28, 35,
- 42, 49, 50, 43, 36, 29, 22, 30,
- 37, 44, 51, 52, 45, 38, 46, 53,
- 54,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4,  5,
+  12, 19, 26, 33, 40, 48, 41, 34,
+  27, 20, 13,  6, 14, 21, 28, 35,
+  42, 49, 50, 43, 36, 29, 22, 30,
+  37, 44, 51, 52, 45, 38, 46, 53,
+  54,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order6[6*6+16] = {
-  0,  1,  8, 16,  9,  2,  3, 10,
- 17, 24, 32, 25, 18, 11,  4,  5,
- 12, 19, 26, 33, 40, 41, 34, 27,
- 20, 13, 21, 28, 35, 42, 43, 36,
- 29, 37, 44, 45,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4,  5,
+  12, 19, 26, 33, 40, 41, 34, 27,
+  20, 13, 21, 28, 35, 42, 43, 36,
+  29, 37, 44, 45,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order5[5*5+16] = {
-  0,  1,  8, 16,  9,  2,  3, 10,
- 17, 24, 32, 25, 18, 11,  4, 12,
- 19, 26, 33, 34, 27, 20, 28, 35,
- 36,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4, 12,
+  19, 26, 33, 34, 27, 20, 28, 35,
+  36,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order4[4*4+16] = {
-  0,  1,  8, 16,  9,  2,  3, 10,
- 17, 24, 25, 18, 11, 19, 26, 27,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2,  3, 10,
+  17, 24, 25, 18, 11, 19, 26, 27,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order3[3*3+16] = {
-  0,  1,  8, 16,  9,  2, 10, 17,
- 18,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8, 16,  9,  2, 10, 17,
+  18,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 const int jpeg_natural_order2[2*2+16] = {
-  0,  1,  8,  9,
- 63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
- 63, 63, 63, 63, 63, 63, 63, 63
+   0,  1,  8,  9,
+  63, 63, 63, 63, 63, 63, 63, 63, /* extra entries for safety in decoder */
+  63, 63, 63, 63, 63, 63, 63, 63
 };
 
 
@@ -174,12 +174,12 @@ jzero_far (void FAR * target, size_t bytestozero)
 
 
 GLOBAL(void)
-jcopy_sample_rows (JSAMPARRAY input_array, int source_row,
-		   JSAMPARRAY output_array, int dest_row,
+jcopy_sample_rows (JSAMPARRAY input_array,
+		   JSAMPARRAY output_array,
 		   int num_rows, JDIMENSION num_cols)
 /* Copy some rows of samples from one place to another.
- * num_rows rows are copied from input_array[source_row++]
- * to output_array[dest_row++]; these areas may overlap for duplication.
+ * num_rows rows are copied from *input_array++ to *output_array++;
+ * these areas may overlap for duplication.
  * The source and destination arrays must be at least as wide as num_cols.
  */
 {
@@ -190,9 +190,6 @@ jcopy_sample_rows (JSAMPARRAY input_array, int source_row,
   register JDIMENSION count;
 #endif
   register int row;
-
-  input_array += source_row;
-  output_array += dest_row;
 
   for (row = num_rows; row > 0; row--) {
     inptr = *input_array++;

--- a/Source/LibJPEG/jversion.h
+++ b/Source/LibJPEG/jversion.h
@@ -1,7 +1,7 @@
 /*
  * jversion.h
  *
- * Copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+ * Copyright (C) 1991-2026, Thomas G. Lane, Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -9,6 +9,6 @@
  */
 
 
-#define JVERSION	"9d  12-Jan-2020"
+#define JVERSION	"10  25-Jan-2026"
 
-#define JCOPYRIGHT	"Copyright (C) 2020, Thomas G. Lane, Guido Vollbeding"
+#define JCOPYRIGHT	"Copyright (C) 2026, Thomas G. Lane, Guido Vollbeding"

--- a/Source/LibJPEG/transupp.c
+++ b/Source/LibJPEG/transupp.c
@@ -1,7 +1,7 @@
 /*
  * transupp.c
  *
- * Copyright (C) 1997-2019, Thomas G. Lane, Guido Vollbeding.
+ * Copyright (C) 1997-2025, Thomas G. Lane, Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -195,12 +195,11 @@ requant_comp (j_decompress_ptr cinfo, jpeg_component_info *compptr,
 	      jvirt_barray_ptr coef_array, JQUANT_TBL *qtblptr1)
 {
   JDIMENSION blk_x, blk_y;
-  int offset_y, k;
+  int offset_y, k, temp, qval;
   JQUANT_TBL *qtblptr;
   JBLOCKARRAY buffer;
   JBLOCKROW block;
   JCOEFPTR ptr;
-  JCOEF temp, qval;
 
   qtblptr = compptr->quant_table;
   for (blk_y = 0; blk_y < compptr->height_in_blocks;
@@ -213,27 +212,27 @@ requant_comp (j_decompress_ptr cinfo, jpeg_component_info *compptr,
       for (blk_x = 0; blk_x < compptr->width_in_blocks; blk_x++) {
 	ptr = block[blk_x];
 	for (k = 0; k < DCTSIZE2; k++) {
-	  temp = qtblptr->quantval[k];
 	  qval = qtblptr1->quantval[k];
-	  if (temp != qval) {
-	    temp *= ptr[k];
-	    /* The following quantization code is a copy from jcdctmgr.c */
+	  if (qval == 0) continue;
+	  temp = qtblptr->quantval[k];
+	  if (temp == qval) continue;
+	  temp *= ptr[k];
+	  /* The following quantization code is a copy from jcdctmgr.c */
 #ifdef FAST_DIVIDE
 #define DIVIDE_BY(a,b)	a /= b
 #else
 #define DIVIDE_BY(a,b)	if (a >= b) a /= b; else a = 0
 #endif
-	    if (temp < 0) {
-	      temp = -temp;
-	      temp += qval>>1;	/* for rounding */
-	      DIVIDE_BY(temp, qval);
-	      temp = -temp;
-	    } else {
-	      temp += qval>>1;	/* for rounding */
-	      DIVIDE_BY(temp, qval);
-	    }
-	    ptr[k] = temp;
+	  if (temp < 0) {
+	    temp = -temp;
+	    temp += qval>>1;	/* for rounding */
+	    DIVIDE_BY(temp, qval);
+	    temp = -temp;
+	  } else {
+	    temp += qval>>1;	/* for rounding */
+	    DIVIDE_BY(temp, qval);
 	  }
+	  ptr[k] = (JCOEF) temp;
 	}
       }
     }
@@ -248,11 +247,11 @@ largest_common_denominator(JCOEF a, JCOEF b)
 {
   JCOEF c;
 
-  do {
+  while (b) {
     c = a % b;
     a = b;
     b = c;
-  } while (c);
+  }
 
   return a;
 }
@@ -269,10 +268,16 @@ adjust_quant(j_decompress_ptr srcinfo, jvirt_barray_ptr *src_coef_arrays,
 
   for (ci = 0; ci < dstinfo->num_components &&
 	       ci < dropinfo->num_components; ci++) {
-    compptr1 = srcinfo->comp_info + ci;
     compptr2 = dropinfo->comp_info + ci;
-    qtblptr1 = compptr1->quant_table;
     qtblptr2 = compptr2->quant_table;
+    if (qtblptr2 == NULL) continue;
+    compptr1 = srcinfo->comp_info + ci;
+    qtblptr1 = compptr1->quant_table;
+    if (qtblptr1 == NULL) {
+      MEMCOPY(dstinfo->quant_tbl_ptrs[compptr1->quant_tbl_no],
+	      qtblptr2, SIZEOF(JQUANT_TBL));
+      continue;
+    }
     for (k = 0; k < DCTSIZE2; k++) {
       if (qtblptr1->quantval[k] != qtblptr2->quantval[k]) {
 	if (trim)
@@ -801,6 +806,92 @@ do_reflect (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
 
 
 LOCAL(void)
+do_negate_no_crop (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+		   JDIMENSION x_crop_offset,
+		   jvirt_barray_ptr *src_coef_arrays)
+/* Negation; done in-place, so no separate dest array is required.
+ * NB: this only works when y_crop_offset is zero.
+ */
+{
+  JDIMENSION blk_x, blk_y, x_crop_blocks;
+  int ci, k, offset_y;
+  JBLOCKARRAY buffer;
+  JBLOCKROW src_row_ptr, dst_row_ptr;
+  JCOEFPTR src_ptr, dst_ptr;
+  jpeg_component_info *compptr;
+
+  for (ci = 0; ci < dstinfo->num_components; ci++) {
+    compptr = dstinfo->comp_info + ci;
+    x_crop_blocks = x_crop_offset * compptr->h_samp_factor;
+    for (blk_y = 0; blk_y < compptr->height_in_blocks;
+	 blk_y += compptr->v_samp_factor) {
+      buffer = (*srcinfo->mem->access_virt_barray)
+	((j_common_ptr) srcinfo, src_coef_arrays[ci], blk_y,
+	 (JDIMENSION) compptr->v_samp_factor, TRUE);
+      for (offset_y = 0; offset_y < compptr->v_samp_factor; offset_y++) {
+	dst_row_ptr = buffer[offset_y];
+	src_row_ptr = dst_row_ptr + x_crop_blocks;
+	for (blk_x = 0; blk_x < compptr->width_in_blocks; blk_x++) {
+	  dst_ptr = dst_row_ptr[blk_x];
+	  src_ptr = src_row_ptr[blk_x];
+	  for (k = 0; k < DCTSIZE2; k++) {
+	    *dst_ptr++ = - *src_ptr++;
+	  }
+	}
+      }
+    }
+  }
+}
+
+
+LOCAL(void)
+do_negate (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+	   JDIMENSION x_crop_offset, JDIMENSION y_crop_offset,
+	   jvirt_barray_ptr *src_coef_arrays,
+	   jvirt_barray_ptr *dst_coef_arrays)
+/* Negation in general cropping case */
+{
+  JDIMENSION dst_blk_x, dst_blk_y, x_crop_blocks, y_crop_blocks;
+  int ci, k, offset_y;
+  JBLOCKARRAY src_buffer, dst_buffer;
+  JBLOCKROW src_row_ptr, dst_row_ptr;
+  JCOEFPTR src_ptr, dst_ptr;
+  jpeg_component_info *compptr;
+
+  /* Here we must output into a separate array because we can't
+   * touch different rows of a single virtual array simultaneously.
+   * Otherwise, this is essentially the same as the routine above.
+   */
+  for (ci = 0; ci < dstinfo->num_components; ci++) {
+    compptr = dstinfo->comp_info + ci;
+    x_crop_blocks = x_crop_offset * compptr->h_samp_factor;
+    y_crop_blocks = y_crop_offset * compptr->v_samp_factor;
+    for (dst_blk_y = 0; dst_blk_y < compptr->height_in_blocks;
+	 dst_blk_y += compptr->v_samp_factor) {
+      dst_buffer = (*srcinfo->mem->access_virt_barray)
+	((j_common_ptr) srcinfo, dst_coef_arrays[ci], dst_blk_y,
+	 (JDIMENSION) compptr->v_samp_factor, TRUE);
+      src_buffer = (*srcinfo->mem->access_virt_barray)
+	((j_common_ptr) srcinfo, src_coef_arrays[ci],
+	 dst_blk_y + y_crop_blocks,
+	 (JDIMENSION) compptr->v_samp_factor, FALSE);
+      for (offset_y = 0; offset_y < compptr->v_samp_factor; offset_y++) {
+	dst_row_ptr = dst_buffer[offset_y];
+	src_row_ptr = src_buffer[offset_y] + x_crop_blocks;
+	for (dst_blk_x = 0; dst_blk_x < compptr->width_in_blocks; dst_blk_x++) {
+	  dst_ptr = dst_row_ptr[dst_blk_x];
+	  src_ptr = src_row_ptr[dst_blk_x];
+	  for (k = 0; k < DCTSIZE2; k++) {
+	    *dst_ptr++ = - *src_ptr++;
+	  }
+	}
+      }
+    }
+  }
+}
+
+
+LOCAL(void)
 do_flip_h_no_crop (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
 		   JDIMENSION x_crop_offset,
 		   jvirt_barray_ptr *src_coef_arrays)
@@ -811,6 +902,7 @@ do_flip_h_no_crop (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
   JDIMENSION MCU_cols, comp_width, blk_x, blk_y, x_crop_blocks;
   int ci, k, offset_y;
   JBLOCKARRAY buffer;
+  JBLOCKROW src_row_ptr, dst_row_ptr;
   JCOEFPTR ptr1, ptr2;
   JCOEF temp1, temp2;
   jpeg_component_info *compptr;
@@ -833,10 +925,11 @@ do_flip_h_no_crop (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
 	((j_common_ptr) srcinfo, src_coef_arrays[ci], blk_y,
 	 (JDIMENSION) compptr->v_samp_factor, TRUE);
       for (offset_y = 0; offset_y < compptr->v_samp_factor; offset_y++) {
+	dst_row_ptr = buffer[offset_y];
 	/* Do the mirroring */
 	for (blk_x = 0; blk_x * 2 < comp_width; blk_x++) {
-	  ptr1 = buffer[offset_y][blk_x];
-	  ptr2 = buffer[offset_y][comp_width - blk_x - 1];
+	  ptr1 = dst_row_ptr[blk_x];
+	  ptr2 = dst_row_ptr[comp_width - blk_x - 1];
 	  /* this unrolled loop doesn't need to know which row it's on... */
 	  for (k = 0; k < DCTSIZE2; k += 2) {
 	    temp1 = *ptr1;	/* swap even column */
@@ -855,9 +948,10 @@ do_flip_h_no_crop (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
 	   * depends on memcpy(), whose behavior is unspecified for overlapping
 	   * source and destination areas.  Sigh.
 	   */
+	  src_row_ptr = dst_row_ptr + x_crop_blocks;
 	  for (blk_x = 0; blk_x < compptr->width_in_blocks; blk_x++) {
-	    jcopy_block_row(buffer[offset_y] + blk_x + x_crop_blocks,
-			    buffer[offset_y] + blk_x,
+	    jcopy_block_row(src_row_ptr + blk_x,
+			    dst_row_ptr + blk_x,
 			    (JDIMENSION) 1);
 	  }
 	}
@@ -882,9 +976,9 @@ do_flip_h (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
   JCOEFPTR src_ptr, dst_ptr;
   jpeg_component_info *compptr;
 
-  /* Here we must output into a separate array because we can't touch
-   * different rows of a single virtual array simultaneously.  Otherwise,
-   * this is essentially the same as the routine above.
+  /* Here we must output into a separate array because we can't
+   * touch different rows of a single virtual array simultaneously.
+   * Otherwise, this is essentially the same as the routine above.
    */
   MCU_cols = srcinfo->output_width /
     (dstinfo->max_h_samp_factor * dstinfo->min_DCT_h_scaled_size);
@@ -945,10 +1039,10 @@ do_flip_v (j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
   jpeg_component_info *compptr;
 
   /* We output into a separate array because we can't touch different
-   * rows of the source virtual array simultaneously.  Otherwise, this
-   * is a pretty straightforward analog of horizontal flip.
-   * Within a DCT block, vertical mirroring is done by changing the signs
-   * of odd-numbered rows.
+   * rows of the source virtual array simultaneously.  Otherwise,
+   * this is a pretty straightforward analog of horizontal flip.
+   * Within a DCT block, vertical mirroring is done by changing
+   * the signs of odd-numbered rows.
    * Partial iMCUs at the bottom edge are copied verbatim.
    */
   MCU_rows = srcinfo->output_height /
@@ -1859,6 +1953,11 @@ jtransform_request_workspace (j_decompress_ptr srcinfo,
     drop_request_from_src(info->drop_ptr, srcinfo);
 #endif
     break;
+  case JXFORM_NEGATE:
+    if (info->y_crop_offset != 0)
+      need_workspace = TRUE;
+    /* do_negate_no_crop doesn't need a workspace array */
+    break;
   }
 
   /* Allocate workspace if needed.
@@ -2299,6 +2398,14 @@ jtransform_execute_transform (j_decompress_ptr srcinfo,
       do_drop(srcinfo, dstinfo, info->x_crop_offset, info->y_crop_offset,
 	      src_coef_arrays, info->drop_ptr, info->drop_coef_arrays,
 	      info->drop_width, info->drop_height);
+    break;
+  case JXFORM_NEGATE:
+    if (info->y_crop_offset != 0)
+      do_negate(srcinfo, dstinfo, info->x_crop_offset, info->y_crop_offset,
+		src_coef_arrays, dst_coef_arrays);
+    else
+      do_negate_no_crop(srcinfo, dstinfo, info->x_crop_offset,
+			src_coef_arrays);
     break;
   }
 }

--- a/Source/LibJPEG/transupp.h
+++ b/Source/LibJPEG/transupp.h
@@ -1,7 +1,7 @@
 /*
  * transupp.h
  *
- * Copyright (C) 1997-2019, Thomas G. Lane, Guido Vollbeding.
+ * Copyright (C) 1997-2025, Thomas G. Lane, Guido Vollbeding.
  * This file is part of the Independent JPEG Group's software.
  * For conditions of distribution and use, see the accompanying README file.
  *
@@ -67,6 +67,9 @@
  * otherwise quantization adaption occurs.  The trim option can be used with
  * the drop option to requantize the drop file to the source file.
  *
+ * A lossless negation function can be used in case an image file contains
+ * inverted component data.
+ *
  * We also provide a lossless-resize option, which is kind of a lossless-crop
  * operation in the DCT coefficient block domain - it discards higher-order
  * coefficients and losslessly preserves lower-order coefficients of a
@@ -112,7 +115,8 @@ typedef enum {
 	JXFORM_ROT_180,		/* 180-degree rotation */
 	JXFORM_ROT_270,		/* 270-degree clockwise (or 90 ccw) */
 	JXFORM_WIPE,		/* wipe */
-	JXFORM_DROP		/* drop */
+	JXFORM_DROP,		/* drop */
+	JXFORM_NEGATE		/* negate */
 } JXFORM_CODE;
 
 /*


### PR DESCRIPTION
Stacked on #65 (libtiff bump). Merge the stack in order: #64 -> #65 -> this one.

Bundled libjpeg was IJG's 9d (Jan 2020) - this is the original IJG libjpeg, not libjpeg-turbo. Went straight to the latest (10, Jan 2026) rather than an intermediate release, since the real changes since 9d are backward-compatible per IJG's own change.log (mostly jpegtran-only additions and platform build-system changes for compilers this project doesn't use).

Found a real bug along the way: upstream's jmorecfg.h flipped an inverted `#ifdef HAVE_BOOLEAN` to the correct `#ifndef HAVE_BOOLEAN` between 9d and 10 - the old condition meant TRUE/FALSE only got defined when a boolean type was already provided, backwards from its own documented intent. Our jconfig.h relied on that bug as a side effect to get TRUE/FALSE defined; fixed by defining them explicitly in jconfig.h, matching upstream's own current template.

Tested: builds clean, full test suite passes, JPEG save/load round trip succeeds.