### PR TITLE
Fix compiler warnings (-Wswitch, -Wshorten-64-to-32, -Wlogical-op-parentheses)

### DIFF
--- a/Source/FreeImage/BitmapAccess.cpp
+++ b/Source/FreeImage/BitmapAccess.cpp
@@ -716,6 +716,8 @@ FreeImage_GetColorType(FIBITMAP *dib) {
 			case FIT_RGBA16:
 			case FIT_RGBAF:
 				return (((FreeImage_GetICCProfile(dib)->flags) & FIICC_COLOR_IS_CMYK) == FIICC_COLOR_IS_CMYK) ? FIC_CMYK : FIC_RGBALPHA;
+			default:
+				break;
 		}
 
 		return FIC_MINISBLACK;
@@ -1081,7 +1083,7 @@ FreeImage_CreateICCProfile(FIBITMAP *dib, void *data, long size) {
 	if(size && profile) {
 		profile->data = malloc(size);
 		if(profile->data) {
-			memcpy(profile->data, data, profile->size = size);
+			memcpy(profile->data, data, profile->size = (DWORD)size);
 		}
 	}
 	return profile;
@@ -1246,7 +1248,7 @@ FreeImage_FindNextMetadata(FIMETADATA *mdhandle, FITAG **tag) {
 	METADATAHEADER *mdh = (METADATAHEADER *)mdhandle->data;
 	TAGMAP *tagmap = mdh->tagmap;
 
-	int current_pos = mdh->pos;
+	int current_pos = (int)mdh->pos;
 	int mapsize     = (int)tagmap->size();
 
 	if(current_pos < mapsize) {

--- a/Source/FreeImage/ColorLookup.cpp
+++ b/Source/FreeImage/ColorLookup.cpp
@@ -574,7 +574,7 @@ FreeImage_LookupX11Color(const char *szColor, BYTE *nRed, BYTE *nGreen, BYTE *nB
          (szColor[3] == 'y' || szColor[3] == 'Y' ) )  {
 
         // grey<num>, or gray<num>, num 1...100
-        i = strtol(szColor+4, NULL, 10);
+        i = (int)strtol(szColor+4, NULL, 10);
         *nRed   = (BYTE)(255.0/100.0 * i);
         *nGreen = *nRed;
         *nBlue  = *nRed;
@@ -768,7 +768,7 @@ FreeImage_LookupSVGColor(const char *szColor, BYTE *nRed, BYTE *nGreen, BYTE *nB
          (szColor[3] == 'y' || szColor[3] == 'Y' ) )  {
 
         // grey<num>, or gray<num>, num 1...100
-        i = strtol(szColor+4, NULL, 10);
+        i = (int)strtol(szColor+4, NULL, 10);
         *nRed   = (BYTE)(255.0/100.0 * i);
         *nGreen = *nRed;
         *nBlue  = *nRed;

--- a/Source/FreeImage/ConversionFloat.cpp
+++ b/Source/FreeImage/ConversionFloat.cpp
@@ -183,6 +183,8 @@ FreeImage_ConvertToFloat(FIBITMAP *dib) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	if(src != dib) {

--- a/Source/FreeImage/ConversionRGBAF.cpp
+++ b/Source/FreeImage/ConversionRGBAF.cpp
@@ -239,6 +239,8 @@ FreeImage_ConvertToRGBAF(FIBITMAP *dib) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	if(src != dib) {

--- a/Source/FreeImage/ConversionRGBF.cpp
+++ b/Source/FreeImage/ConversionRGBF.cpp
@@ -232,6 +232,8 @@ FreeImage_ConvertToRGBF(FIBITMAP *dib) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	if(src != dib) {

--- a/Source/FreeImage/ConversionType.cpp
+++ b/Source/FreeImage/ConversionType.cpp
@@ -285,6 +285,8 @@ FreeImage_ConvertToStandardType(FIBITMAP *src, BOOL scale_linear) {
 			break;
 		case FIT_RGBAF:		// 128-bit RGBA float image: 4 x 32-bit IEEE floating point
 			break;
+		default:
+			break;
 	}
 
 	if(NULL == dst) {
@@ -355,6 +357,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_UINT16:
@@ -389,6 +393,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_INT16:
@@ -418,6 +424,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBF:
 					break;
 				case FIT_RGBAF:
+					break;
+				default:
 					break;
 			}
 			break;
@@ -449,6 +457,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 					break;
 				case FIT_RGBAF:
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_INT32:
@@ -478,6 +488,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBF:
 					break;
 				case FIT_RGBAF:
+					break;
+				default:
 					break;
 			}
 			break;
@@ -510,6 +522,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_DOUBLE:
@@ -538,6 +552,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 					break;
 				case FIT_RGBAF:
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_COMPLEX:
@@ -563,6 +579,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBF:
 					break;
 				case FIT_RGBAF:
+					break;
+				default:
 					break;
 			}
 			break;
@@ -596,6 +614,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_RGBA16:
@@ -628,6 +648,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
 					break;
+				default:
+					break;
 			}
 			break;
 		case FIT_RGBF:
@@ -655,6 +677,8 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 					break;
 				case FIT_RGBAF:
 					dst = FreeImage_ConvertToRGBAF(src);
+					break;
+				default:
 					break;
 			}
 			break;
@@ -684,7 +708,11 @@ FreeImage_ConvertToType(FIBITMAP *src, FREE_IMAGE_TYPE dst_type, BOOL scale_line
 				case FIT_RGBF:
 					dst = FreeImage_ConvertToRGBF(src);
 					break;
+				default:
+					break;
 			}
+			break;
+		default:
 			break;
 	}
 

--- a/Source/FreeImage/FreeImageIO.cpp
+++ b/Source/FreeImage/FreeImageIO.cpp
@@ -136,7 +136,7 @@ _MemoryWriteProc(void *buffer, unsigned size, unsigned count, fi_handle handle) 
 			return 0;
 		}
 		mem_header->data = newdata;
-		mem_header->data_length = newdatalen;
+		mem_header->data_length = (int)newdatalen;
 	}
 
 	memcpy((char *)mem_header->data + mem_header->current_position, buffer, required_bytes);
@@ -180,7 +180,7 @@ _MemorySeekProc(fi_handle handle, long offset, int origin) {
 		case SEEK_SET: //can fseek() to 0-7FFFFFFF always
 			if ((offset >= 0) && (offset <= std::numeric_limits<int>::max())) {
 				// the 64-bit long offset may overflow when casted to int
-				mem_header->current_position = offset;
+				mem_header->current_position = (int)offset;
 				return 0;
 			}
 			break;
@@ -188,7 +188,7 @@ _MemorySeekProc(fi_handle handle, long offset, int origin) {
 		case SEEK_CUR:
 			if (((mem_header->current_position + offset) >= 0) && ((mem_header->current_position + offset) <= std::numeric_limits<int>::max())) {
 				// the 64-bit result may overflow when casted to int
-				mem_header->current_position += offset;
+				mem_header->current_position = (int)(mem_header->current_position + offset);
 				return 0;
 			}
 			break;
@@ -196,7 +196,7 @@ _MemorySeekProc(fi_handle handle, long offset, int origin) {
 		case SEEK_END:
 			if (((mem_header->file_length + offset) >= 0) && ((mem_header->file_length + offset) <= std::numeric_limits<int>::max())) {
 				// the 64-bit result may overflow when casted to int
-				mem_header->current_position = mem_header->file_length + offset;
+				mem_header->current_position = (int)(mem_header->file_length + offset);
 				return 0;
 			}
 			break;

--- a/Source/FreeImage/J2KHelper.cpp
+++ b/Source/FreeImage/J2KHelper.cpp
@@ -30,7 +30,7 @@ static OPJ_UINT64
 _LengthProc(J2KFIO_t *fio) {
 	long start_pos = fio->io->tell_proc(fio->handle);
 	fio->io->seek_proc(fio->handle, 0, SEEK_END);
-	unsigned file_length = fio->io->tell_proc(fio->handle) - start_pos;
+	unsigned file_length = (unsigned)(fio->io->tell_proc(fio->handle) - start_pos);
 	fio->io->seek_proc(fio->handle, start_pos, SEEK_SET);
 	return (OPJ_UINT64)file_length;
 }

--- a/Source/FreeImage/MNGHelper.cpp
+++ b/Source/FreeImage/MNGHelper.cpp
@@ -329,7 +329,7 @@ mng_CountPNGChunks(FreeImageIO *io, fi_handle handle, long inPos, unsigned *m_To
 				case IEND:
 					mEnd = TRUE;		
 					// the length below includes 4 bytes CRC, but no bytes for Length
-					*m_TotalBytesOfChunks = io->tell_proc(handle) - inPos;
+					*m_TotalBytesOfChunks = (unsigned)(io->tell_proc(handle) - inPos);
 					break;		
 				
 				case UNKNOWN_CHUNCK:
@@ -375,7 +375,7 @@ mng_FindChunk(FIMEMORY *hPngMemory, BYTE *chunk_name, long offset, DWORD *start_
 	try {
 	
 		// skip the signature and/or any following chunk(s)
-		DWORD chunk_pos = offset;
+		DWORD chunk_pos = (DWORD)offset;
 
 		while(1) {
 			// get chunk length

--- a/Source/FreeImage/NNQuantizer.cpp
+++ b/Source/FreeImage/NNQuantizer.cpp
@@ -338,7 +338,7 @@ void NNQuantizer::getSample(long pos, int *b, int *g, int *r) {
 	// get equivalent pixel coordinates 
 	// - assume it's a 24-bit image -
 	int x = pos % img_line;
-	int y = pos / img_line;
+	int y = (int)(pos / img_line);
 
 	BYTE *bits = FreeImage_GetScanLine(dib_ptr, y) + x;
 
@@ -357,7 +357,7 @@ void NNQuantizer::learn(int sampling_factor) {
 	lengthcount = img_width * img_height * 3;
 
 	// number of samples used for the learning phase
-	samplepixels = lengthcount / (3 * sampling_factor);
+	samplepixels = (int)(lengthcount / (3 * sampling_factor));
 
 	// decrease learning rate after delta pixel presentations
 	delta = samplepixels / ncycles;

--- a/Source/FreeImage/PluginBMP.cpp
+++ b/Source/FreeImage/PluginBMP.cpp
@@ -1224,18 +1224,18 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		switch(type) {
 			case 12:
 				// OS/2 and also all Windows versions since Windows 3.0
-				return LoadOS21XBMP(io, handle, flags, offset_in_file + bitmapfileheader.bfOffBits);
+				return LoadOS21XBMP(io, handle, flags, (unsigned)(offset_in_file + bitmapfileheader.bfOffBits));
 
 			case 64:
 				// OS/2
-				return LoadOS22XBMP(io, handle, flags, offset_in_file + bitmapfileheader.bfOffBits);
+				return LoadOS22XBMP(io, handle, flags, (unsigned)(offset_in_file + bitmapfileheader.bfOffBits));
 
 			case 40:	// BITMAPINFOHEADER - all Windows versions since Windows 3.0
 			case 52:	// BITMAPV2INFOHEADER (undocumented, partially supported)
 			case 56:	// BITMAPV3INFOHEADER (undocumented, partially supported)
 			case 108:	// BITMAPV4HEADER - all Windows versions since Windows 95/NT4 (partially supported)
 			case 124:	// BITMAPV5HEADER - Windows 98/2000 and newer (partially supported)
-				return LoadWindowsBMP(io, handle, flags, offset_in_file + bitmapfileheader.bfOffBits, type);
+				return LoadWindowsBMP(io, handle, flags, (unsigned)(offset_in_file + bitmapfileheader.bfOffBits), type);
 
 			default:
 				break;

--- a/Source/FreeImage/PluginIFF.cpp
+++ b/Source/FreeImage/PluginIFF.cpp
@@ -240,7 +240,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			SwapLong(&ch_size);
 #endif
 
-			unsigned ch_end = io->tell_proc(handle) + ch_size;
+			unsigned ch_end = (unsigned)(io->tell_proc(handle) + ch_size);
 
 			if (ch_type == ID_BMHD) {			// Bitmap Header
 				if (dib)

--- a/Source/FreeImage/PluginJPEG.cpp
+++ b/Source/FreeImage/PluginJPEG.cpp
@@ -779,7 +779,7 @@ jpeg_write_comment(j_compress_ptr cinfo, FIBITMAP *dib) {
 
 		if(NULL != tag_value) {
 			for(long i = 0; i < (long)strlen(tag_value); i+= MAX_BYTES_IN_MARKER) {
-				jpeg_write_marker(cinfo, JPEG_COM, (BYTE*)tag_value + i, MIN((long)strlen(tag_value + i), MAX_BYTES_IN_MARKER));
+				jpeg_write_marker(cinfo, JPEG_COM, (BYTE*)tag_value + i, (unsigned)MIN((long)strlen(tag_value + i), MAX_BYTES_IN_MARKER));
 			}
 			return TRUE;
 		}
@@ -805,7 +805,7 @@ jpeg_write_icc_profile(j_compress_ptr cinfo, FIBITMAP *dib) {
 		memcpy(profile, icc_signature, 12);
 
 		for(long i = 0; i < (long)iccProfile->size; i += MAX_DATA_BYTES_IN_MARKER) {
-			unsigned length = MIN((long)(iccProfile->size - i), MAX_DATA_BYTES_IN_MARKER);
+			unsigned length = (unsigned)MIN((long)(iccProfile->size - i), MAX_DATA_BYTES_IN_MARKER);
 			// sequence number
 			profile[12] = (BYTE) ((i / MAX_DATA_BYTES_IN_MARKER) + 1);
 			// number of markers
@@ -841,7 +841,7 @@ jpeg_write_iptc_profile(j_compress_ptr cinfo, FIBITMAP *dib) {
 
 			// write the profile
 			for(long i = 0; i < (long)profile_size; i += 65517L) {
-				unsigned length = MIN((long)profile_size - i, 65517L);
+				unsigned length = (unsigned)MIN((long)profile_size - i, 65517L);
 				unsigned roundup = length & 0x01;	// needed for Photoshop
 				BYTE *iptc_profile = (BYTE*)malloc(length + roundup + tag_length);
 				if(iptc_profile == NULL) break;
@@ -896,7 +896,7 @@ jpeg_write_xmp_profile(j_compress_ptr cinfo, FIBITMAP *dib) {
 			memcpy(profile, xmp_signature, xmp_header_size);
 
 			for(DWORD i = 0; i < tag_length; i += 65504L) {
-				unsigned length = MIN((long)(tag_length - i), 65504L);
+				unsigned length = (unsigned)MIN((long)(tag_length - i), 65504L);
 				
 				memcpy(profile + xmp_header_size, tag_value + i, length);
 				jpeg_write_marker(cinfo, EXIF_MARKER, profile, (length + xmp_header_size));
@@ -939,7 +939,7 @@ jpeg_write_exif_profile_raw(j_compress_ptr cinfo, FIBITMAP *dib) {
 			if(profile == NULL) return FALSE;
 
 			for(DWORD i = 0; i < tag_length; i += 65504L) {
-				unsigned length = MIN((long)(tag_length - i), 65504L);
+				unsigned length = (unsigned)MIN((long)(tag_length - i), 65504L);
 				
 				memcpy(profile, tag_value + i, length);
 				jpeg_write_marker(cinfo, EXIF_MARKER, profile, length);
@@ -965,7 +965,7 @@ jpeg_write_jfxx(j_compress_ptr cinfo, FIBITMAP *dib) {
 		return TRUE;
 	}
 	// check for a compatible output format
-	if((FreeImage_GetImageType(thumbnail) != FIT_BITMAP) || (FreeImage_GetBPP(thumbnail) != 8) && (FreeImage_GetBPP(thumbnail) != 24)) {
+	if((FreeImage_GetImageType(thumbnail) != FIT_BITMAP) || ((FreeImage_GetBPP(thumbnail) != 8) && (FreeImage_GetBPP(thumbnail) != 24))) {
 		FreeImage_OutputMessageProc(s_format_id, FI_MSG_WARNING_INVALID_THUMBNAIL);
 		return FALSE;
 	}

--- a/Source/FreeImage/PluginPFM.cpp
+++ b/Source/FreeImage/PluginPFM.cpp
@@ -281,7 +281,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			for (int y = 0; y < height; y++) {	
 				FIRGBF *bits = (FIRGBF*)FreeImage_GetScanLine(dib, height - 1 - y);
 
-				if(io->read_proc(lineBuffer, sizeof(float), lineWidth, handle) != lineWidth) {
+				if(io->read_proc(lineBuffer, sizeof(float), (unsigned)lineWidth, handle) != lineWidth) {
 					throw "Read error";
 				}
 				float *channel = lineBuffer;
@@ -315,7 +315,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			for (int y = 0; y < height; y++) {	
 				float *bits = (float*)FreeImage_GetScanLine(dib, height - 1 - y);
 
-				if(io->read_proc(lineBuffer, sizeof(float), lineWidth, handle) != lineWidth) {
+				if(io->read_proc(lineBuffer, sizeof(float), (unsigned)lineWidth, handle) != lineWidth) {
 					throw "Read error";
 				}
 				float *channel = lineBuffer;

--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -991,7 +991,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 	FIBITMAP* dib = NULL;
 	try {		
 		// Skip empty 512 byte header.
-		if ( !io->seek_proc(handle, 512, SEEK_CUR) == 0 )
+		if ( io->seek_proc(handle, 512, SEEK_CUR) != 0 )
 			return NULL;
 		
 		// Read PICT header
@@ -1311,6 +1311,8 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 				dib = FreeImage_Allocate(width, height, 8);
 				break;
 			}			
+			default:
+				break;
 		}		
 		
 		if ( dib ) {

--- a/Source/FreeImage/PluginTARGA.cpp
+++ b/Source/FreeImage/PluginTARGA.cpp
@@ -1523,7 +1523,7 @@ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void
 		
 		assert(sizeof(ex) == 495);
 		ex.extension_size = sizeof(ex);
-		ex.postage_stamp_offset = extension_offset + ex.extension_size + 0 /*< no Scan Line Table*/;
+		ex.postage_stamp_offset = (DWORD)(extension_offset + ex.extension_size + 0 /*< no Scan Line Table*/);
 		ex.attributes_type = FreeImage_GetBPP(dib) == 32 ? 3 /*< useful Alpha channel data*/ : 0 /*< no Alpha data*/;
 		
 #ifdef FREEIMAGE_BIGENDIAN
@@ -1566,7 +1566,7 @@ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void
 	// write the footer
 	
 	TGAFOOTER footer;
-	footer.extension_offset = extension_offset;
+	footer.extension_offset = (DWORD)extension_offset;
 	footer.developer_offset = 0;
 	strcpy(footer.signature, "TRUEVISION-XFILE.");
 	

--- a/Source/FreeImage/PluginTIFF.cpp
+++ b/Source/FreeImage/PluginTIFF.cpp
@@ -636,6 +636,8 @@ WriteImageType(TIFF *tiff, FREE_IMAGE_TYPE fit) {
 		case FIT_COMPLEX:	// array of COMPLEX : 2 x 64-bit
 			TIFFSetField(tiff, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_COMPLEXIEEEFP);
 			break;
+		default:
+			break;
 	}
 }
 
@@ -1182,7 +1184,7 @@ IsValidBitsPerSample(uint16_t photometric, uint16_t bitspersample, uint16_t samp
 		case 32:
 			if((photometric == PHOTOMETRIC_MINISWHITE) || (photometric == PHOTOMETRIC_MINISBLACK) || (photometric == PHOTOMETRIC_LOGLUV)) {
 				return TRUE;
-			} else if((photometric == PHOTOMETRIC_RGB) && (samplesperpixel == 3) || (samplesperpixel == 4)) {
+			} else if((photometric == PHOTOMETRIC_RGB) && ((samplesperpixel == 3) || (samplesperpixel == 4))) {
 				// RGB[A]F
 				return TRUE;
 			} else {

--- a/Source/FreeImage/ZLibInterface.cpp
+++ b/Source/FreeImage/ZLibInterface.cpp
@@ -53,14 +53,14 @@ FreeImage_ZLibCompress(BYTE *target, DWORD target_size, BYTE *source, DWORD sour
 			FreeImage_OutputMessageProc(FIF_UNKNOWN, "Zlib error : %s", zError(zerr));
 			return 0;
 		case Z_OK:
-			return dest_len;
+			return (DWORD)dest_len;
 	}
 
 	return 0;
 }
 
 /**
-Decompresses a source buffer into a target buffer, using the ZLib library. 
+Decompresses a source buffer into a target buffer, using the ZLib library.
 Upon entry, target_size is the total size of the destination buffer, 
 which must be large enough to hold the entire uncompressed data. 
 The size of the uncompressed data must have been saved previously by the compressor 
@@ -86,14 +86,14 @@ FreeImage_ZLibUncompress(BYTE *target, DWORD target_size, BYTE *source, DWORD so
 			FreeImage_OutputMessageProc(FIF_UNKNOWN, "Zlib error : %s", zError(zerr));
 			return 0;
 		case Z_OK:
-			return dest_len;
+			return (DWORD)dest_len;
 	}
 
 	return 0;
 }
 
 /**
-Compresses a source buffer into a target buffer, using the ZLib library. 
+Compresses a source buffer into a target buffer, using the ZLib library.
 On success, the target buffer contains a GZIP compatible layout.
 Upon entry, target_size is the total size of the destination buffer, 
 which must be at least 0.1% larger than source_size plus 24 bytes. 
@@ -108,7 +108,7 @@ which must be at least 0.1% larger than source_size plus 24 bytes.
 DWORD DLL_CALLCONV 
 FreeImage_ZLibGZip(BYTE *target, DWORD target_size, BYTE *source, DWORD source_size) {
 	uLongf dest_len = (uLongf)target_size - 12;
-	DWORD crc = crc32(0L, NULL, 0);
+	DWORD crc = (DWORD)crc32(0L, NULL, 0);
 
     // set up header (stolen from zlib/gzio.c)
     sprintf((char *)target, "%c%c%c%c%c%c%c%c", 0x1f, 0x8b,
@@ -127,10 +127,10 @@ FreeImage_ZLibGZip(BYTE *target, DWORD target_size, BYTE *source, DWORD source_s
             const BYTE gzip_os_code = OS_CODE;
 #endif
             BYTE *p = target + 8; *p++ = 2; *p = gzip_os_code; // xflags, os_code
- 	        crc = crc32(crc, source, source_size);
+ 	        crc = (DWORD)crc32(crc, source, source_size);
 	        memcpy(target + 4 + dest_len, &crc, 4);
 	        memcpy(target + 8 + dest_len, &source_size, 4);
-            return dest_len + 12;
+            return (DWORD)(dest_len + 12);
         }
 	}
 	return 0;
@@ -230,5 +230,5 @@ If source is NULL, this function returns the required initial value for the crc.
 DWORD DLL_CALLCONV 
 FreeImage_ZLibCRC32(DWORD crc, BYTE *source, DWORD source_size) {
 
-    return crc32(crc, source, source_size);
+    return (DWORD)crc32(crc, source, source_size);
 }

--- a/Source/FreeImage/tmoReinhard05.cpp
+++ b/Source/FreeImage/tmoReinhard05.cpp
@@ -81,7 +81,7 @@ ToneMappingReinhard05(FIBITMAP *dib, FIBITMAP *Y, float f, float m, float a, flo
 	// get statistics about the data (but only if its really needed)
 
 	f = exp(-f);
-	if((m == 0) || (a != 1) && (c != 1)) {
+	if((m == 0) || ((a != 1) && (c != 1))) {
 		// avoid these calculations if its not needed after ...
 		LuminanceFromY(Y, &maxLum, &minLum, &Lav, &Llav);
 		k = (log(maxLum) - Llav) / (log(maxLum) - log(minLum));

--- a/Source/FreeImageToolkit/BSplineRotate.cpp
+++ b/Source/FreeImageToolkit/BSplineRotate.cpp
@@ -573,7 +573,7 @@ Rotate8Bit(FIBITMAP *dib, double angle, double x_shift, double y_shift, double x
 	// copy data samples
 	for(y = 0; y < height; y++) {
 		double *pImage = &ImageRasterArray[y*width];
-		BYTE *src_bits = FreeImage_GetScanLine(dib, height-1-y);
+		BYTE *src_bits = FreeImage_GetScanLine(dib, (int)(height-1-y));
 
 		for(x = 0; x < width; x++) {
 			pImage[x] = (double)src_bits[x];
@@ -602,7 +602,7 @@ Rotate8Bit(FIBITMAP *dib, double angle, double x_shift, double y_shift, double x
 
 	// visit all pixels of the output image and assign their value
 	for(y = 0; y < height; y++) {
-		BYTE *dst_bits = FreeImage_GetScanLine(dst, height-1-y);
+		BYTE *dst_bits = FreeImage_GetScanLine(dst, (int)(height-1-y));
 		
 		x0 = a12 * (double)y + x_shift;
 		y0 = a22 * (double)y + y_shift;

--- a/Source/FreeImageToolkit/Channels.cpp
+++ b/Source/FreeImageToolkit/Channels.cpp
@@ -212,7 +212,7 @@ FreeImage_SetChannel(FIBITMAP *dst, FIBITMAP *src, FREE_IMAGE_COLOR_CHANNEL chan
 	// src image should be grayscale, dst image should be RGB or RGBA
 	FREE_IMAGE_COLOR_TYPE src_type = FreeImage_GetColorType(src);
 	FREE_IMAGE_COLOR_TYPE dst_type = FreeImage_GetColorType(dst);
-	if((dst_type != FIC_RGB) && (dst_type != FIC_RGBALPHA) || (src_type != FIC_MINISBLACK)) {
+	if(((dst_type != FIC_RGB) && (dst_type != FIC_RGBALPHA)) || (src_type != FIC_MINISBLACK)) {
 		return FALSE;
 	}
 
@@ -224,7 +224,7 @@ FreeImage_SetChannel(FIBITMAP *dst, FIBITMAP *src, FREE_IMAGE_COLOR_CHANNEL chan
 		// src image should be grayscale, dst image should be 24- or 32-bit
 		unsigned src_bpp = FreeImage_GetBPP(src);
 		unsigned dst_bpp = FreeImage_GetBPP(dst);
-		if((src_bpp != 8) || (dst_bpp != 24) && (dst_bpp != 32))
+		if((src_bpp != 8) || ((dst_bpp != 24) && (dst_bpp != 32)))
 			return FALSE;
 
 
@@ -268,7 +268,7 @@ FreeImage_SetChannel(FIBITMAP *dst, FIBITMAP *src, FREE_IMAGE_COLOR_CHANNEL chan
 		// src image should be grayscale, dst image should be 48- or 64-bit
 		unsigned src_bpp = FreeImage_GetBPP(src);
 		unsigned dst_bpp = FreeImage_GetBPP(dst);
-		if((src_bpp != 16) || (dst_bpp != 48) && (dst_bpp != 64))
+		if((src_bpp != 16) || ((dst_bpp != 48) && (dst_bpp != 64)))
 			return FALSE;
 
 
@@ -312,7 +312,7 @@ FreeImage_SetChannel(FIBITMAP *dst, FIBITMAP *src, FREE_IMAGE_COLOR_CHANNEL chan
 		// src image should be grayscale, dst image should be 96- or 128-bit
 		unsigned src_bpp = FreeImage_GetBPP(src);
 		unsigned dst_bpp = FreeImage_GetBPP(dst);
-		if((src_bpp != 32) || (dst_bpp != 96) && (dst_bpp != 128))
+		if((src_bpp != 32) || ((dst_bpp != 96) && (dst_bpp != 128)))
 			return FALSE;
 
 
@@ -424,6 +424,8 @@ FreeImage_GetComplexChannel(FIBITMAP *src, FREE_IMAGE_COLOR_CHANNEL channel) {
 					}
 				}
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -481,6 +483,8 @@ FreeImage_SetComplexChannel(FIBITMAP *dst, FIBITMAP *src, FREE_IMAGE_COLOR_CHANN
 					dst_bits[x].i = src_bits[x];
 				}
 			}
+			break;
+		default:
 			break;
 	}
 

--- a/Source/FreeImageToolkit/ClassicRotate.cpp
+++ b/Source/FreeImageToolkit/ClassicRotate.cpp
@@ -168,6 +168,8 @@ HorizontalSkew(FIBITMAP *src, FIBITMAP *dst, int row, int iOffset, double dWeigh
 		case FIT_RGBAF:
 			HorizontalSkewT<float>(src, dst, row, iOffset, dWeight, bkcolor);
 			break;
+		default:
+			break;
 	}
 }
 
@@ -307,6 +309,8 @@ VerticalSkew(FIBITMAP *src, FIBITMAP *dst, int col, int iOffset, double dWeight,
 			case FIT_RGBAF:
 				VerticalSkewT<float>(src, dst, col, iOffset, dWeight, bkcolor);
 				break;
+		default:
+			break;
 	}
 } 
 
@@ -429,6 +433,8 @@ Rotate90(FIBITMAP *src) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	return dst;
@@ -496,6 +502,8 @@ Rotate180(FIBITMAP *src) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	return dst;
@@ -621,6 +629,8 @@ Rotate270(FIBITMAP *src) {
 			}
 		}
 		break;
+		default:
+			break;
 	}
 
 	return dst;
@@ -906,6 +916,8 @@ FreeImage_Rotate(FIBITMAP *dib, double angle, const void *bkcolor) {
 				return dst;
 			}
 			break;
+			default:
+				break;
 		}
 
 	} catch(int) {

--- a/Source/FreeImageToolkit/Rescale.cpp
+++ b/Source/FreeImageToolkit/Rescale.cpp
@@ -173,10 +173,14 @@ FreeImage_MakeThumbnail(FIBITMAP *dib, int max_pixel_size, BOOL convert) {
 				bitmap = FreeImage_ToneMapping(thumbnail, FITMO_DRAGO03);
 				break;
 			case FIT_RGBAF:
+			{
 				// no way to keep the transparency yet ...
 				FIBITMAP *rgbf = FreeImage_ConvertToRGBF(thumbnail);
 				bitmap = FreeImage_ToneMapping(rgbf, FITMO_DRAGO03);
 				FreeImage_Unload(rgbf);
+				break;
+			}
+			default:
 				break;
 		}
 		if(bitmap != NULL) {

--- a/Source/FreeImageToolkit/Resize.cpp
+++ b/Source/FreeImageToolkit/Resize.cpp
@@ -1272,6 +1272,8 @@ void CResizeEngine::horizontalFilter(FIBITMAP *const src, unsigned height, unsig
 			}
 		}
 		break;
+		default:
+			break;
 	}
 }
 
@@ -2112,5 +2114,7 @@ void CResizeEngine::verticalFilter(FIBITMAP *const src, unsigned width, unsigned
 			}
 		}
 		break;
+		default:
+			break;
 	}
 }

--- a/Source/Metadata/Exif.cpp
+++ b/Source/Metadata/Exif.cpp
@@ -1193,7 +1193,7 @@ tiff_write_ifd(FIBITMAP *dib, FREE_IMAGE_MDMODEL md_model, FIMEMORY *hmem) {
 			unsigned ifd_size = 2 + 12 * metadata_count;
 			FreeImage_WriteMemory(&empty_byte, 1, ifd_size, hmem);
 			// record the offset used to write values > 4-bytes
-			ifd_offset = FreeImage_TellMemory(hmem);
+			ifd_offset = (DWORD)FreeImage_TellMemory(hmem);
 			// rewind
 			FreeImage_SeekMemory(hmem, start_of_file, SEEK_SET);
 		}
@@ -1237,7 +1237,7 @@ tiff_write_ifd(FIBITMAP *dib, FREE_IMAGE_MDMODEL md_model, FIMEMORY *hmem) {
 					FreeImage_WriteMemory(&empty_byte, 1, 1, hmem);
 				}
 				// next offset to use
-				ifd_offset = FreeImage_TellMemory(hmem);
+				ifd_offset = (DWORD)FreeImage_TellMemory(hmem);
 				// rewind
 				FreeImage_SeekMemory(hmem, current_position, SEEK_SET);
 			}

--- a/Source/Metadata/FIRational.cpp
+++ b/Source/Metadata/FIRational.cpp
@@ -63,6 +63,8 @@ FIRational::FIRational(const FITAG *tag) {
 			initialize((LONG)pvalue[0], (LONG)pvalue[1]);
 			break;
 		}
+		default:
+			break;
 	}
 }
 

--- a/Source/Metadata/TagLib.cpp
+++ b/Source/Metadata/TagLib.cpp
@@ -1645,6 +1645,8 @@ TagLib::getFreeImageModel(MDMODEL model) {
 
 		case ANIMATION:
 			return FIMD_ANIMATION;
+		default:
+			break;
 	}
 
 	return FIMD_NODATA;


### PR DESCRIPTION
Reported from an openFrameworks apothecary CI build ([run 32219237031](https://github.com/openframeworks/apothecary/actions/runs/32219237031/job/95966510685?pr=587)). Reproduced locally by building with the same warning flags enabled and fixed everything in scope (`Source/FreeImage`, `FreeImageToolkit`, `Metadata` - not the bundled third-party libs, which weren't part of the reported warnings).

**`-Wswitch`** (missing enum cases): added `default: break;` to switches that intentionally only handle a subset of `FREE_IMAGE_TYPE`/`FREE_IMAGE_COLOR_CHANNEL`/etc values. Mechanical/behavior-preserving, but surfaced one real pre-existing bug: `Rescale.cpp`'s `case FIT_RGBAF` declared a local without a block scope, which becomes a hard compile error ("cannot jump to case label") once anything follows it in the switch - wrapped that case body in braces.

**`-Wshorten-64-to-32`**: added explicit casts at ~25 sites (file offset arithmetic via `tell_proc`/`seek_proc` returning `long`, zlib's `uLong`/`uLongf`, `strtol` results) assigned into narrower `DWORD`/`unsigned`/`int` fields. All are already implicitly narrowed today - just making the intentional narrowing visible to the compiler, not changing behavior.

**`-Wlogical-op-parentheses` / `-Wlogical-not-parentheses`**: reviewed each of the 7 sites individually rather than blindly adding parens, since `&&` binding tighter than `||` can silently hide a real logic bug.
- Six were confirmed correct as originally written (verified against surrounding comments/context) and just needed explicit parens for clarity.
- One was a genuine bug: `PluginTIFF.cpp`'s `IsValidBitsPerSample()` checked `(photometric == PHOTOMETRIC_RGB) && (samplesperpixel == 3) || (samplesperpixel == 4)` for its `// RGB[A]F` 32-bit-per-sample validation - as written, any 4-samples-per-pixel image (e.g. CMYK) would incorrectly validate as RGBA float, regardless of photometric. Fixed to `(photometric == PHOTOMETRIC_RGB) && ((samplesperpixel == 3) || (samplesperpixel == 4))`, matching the comment's clear intent.
- Simplified a `-Wlogical-not-parentheses` site in `PluginPICT.cpp` (`!x == 0`) to the unambiguous `x != 0` - mathematically equivalent either way it's parsed, but confusing to read.

**Tested**: rebuilding with all four warning flags now produces zero warnings in the affected files, the full test suite passes, and a plain default-flags build (matching normal CI) also builds clean.