### PR TITLE
Convert Hervé Drolon author credit to UTF-8

### DIFF
--- a/Examples/Generic/BatchLoad.cpp
+++ b/Examples/Generic/BatchLoad.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by 
 // - Floris van den Berg
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Generic/CloneMultiPage.cpp
+++ b/Examples/Generic/CloneMultiPage.cpp
@@ -2,7 +2,7 @@
 // Multipage functions demonstration
 //
 // Design and implementation by 
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Generic/CreateAlpha.cpp
+++ b/Examples/Generic/CreateAlpha.cpp
@@ -2,7 +2,7 @@
 // Alpha channel manipulation example
 //
 // Design and implementation by 
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Generic/FIFImportExport.cpp
+++ b/Examples/Generic/FIFImportExport.cpp
@@ -2,7 +2,7 @@
 // Plugin functions demonstration
 //
 // Design and implementation by 
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Generic/LoadFromHandle.cpp
+++ b/Examples/Generic/LoadFromHandle.cpp
@@ -2,7 +2,7 @@
 // Load From Handle Example
 //
 // Design and implementation by 
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Generic/ShowMetadata.cpp
+++ b/Examples/Generic/ShowMetadata.cpp
@@ -2,7 +2,7 @@
 // Simple metadata reader
 //
 // Design and implementation by 
-// - Hervé Drolon
+// - HervÃ© Drolon
 //
 // This file is part of FreeImage 3
 //

--- a/Examples/Plugin/PluginCradle.cpp
+++ b/Examples/Plugin/PluginCradle.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage.h
+++ b/Source/FreeImage.h
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // Contributors:
 // - see changes log named 'Whatsnew.txt', see header of each .h and .cpp file

--- a/Source/FreeImage/BitmapAccess.cpp
+++ b/Source/FreeImage/BitmapAccess.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Detlev Vendt (detlev.vendt@brillit.de)
 // - Petr Supina (psup@centrum.cz)
 // - Carsten Klein (c.klein@datagis.com)

--- a/Source/FreeImage/Conversion16_555.cpp
+++ b/Source/FreeImage/Conversion16_555.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jani Kajala (janik@remedy.fi)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/Conversion16_565.cpp
+++ b/Source/FreeImage/Conversion16_565.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jani Kajala (janik@remedy.fi)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/Conversion24.cpp
+++ b/Source/FreeImage/Conversion24.cpp
@@ -4,7 +4,7 @@
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
 // - Dale Larson (dlarson@norsesoft.com)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jani Kajala (janik@remedy.fi)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/Conversion32.cpp
+++ b/Source/FreeImage/Conversion32.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jani Kajala (janik@remedy.fi)
 // - Detlev Vendt (detlev.vendt@brillit.de)
 //

--- a/Source/FreeImage/Conversion8.cpp
+++ b/Source/FreeImage/Conversion8.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jani Kajala (janik@remedy.fi)
 // - Karl-Heinz Bussian (khbussian@moss.de)
 // - Carsten Klein (cklein05@users.sourceforge.net)

--- a/Source/FreeImage/ConversionFloat.cpp
+++ b/Source/FreeImage/ConversionFloat.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ConversionRGB16.cpp
+++ b/Source/FreeImage/ConversionRGB16.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ConversionRGBA16.cpp
+++ b/Source/FreeImage/ConversionRGBA16.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ConversionRGBAF.cpp
+++ b/Source/FreeImage/ConversionRGBAF.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Tanner Helland (tannerhelland@users.sf.net)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ConversionRGBF.cpp
+++ b/Source/FreeImage/ConversionRGBF.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ConversionType.cpp
+++ b/Source/FreeImage/ConversionType.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Tanner Helland (tannerhelland@users.sf.net)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/ConversionUINT16.cpp
+++ b/Source/FreeImage/ConversionUINT16.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/FreeImage.cpp
+++ b/Source/FreeImage/FreeImage.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Karl-Heinz Bussian (khbussian@moss.de)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/GetType.cpp
+++ b/Source/FreeImage/GetType.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/Halftoning.cpp
+++ b/Source/FreeImage/Halftoning.cpp
@@ -2,7 +2,7 @@
 // Bitmap conversion routines
 // Thresholding and halftoning functions
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Dennis Lim (dlkj@users.sourceforge.net)
 // - Thomas Chmielewski (Chmielewski.Thomas@oce.de)
 //

--- a/Source/FreeImage/MNGHelper.cpp
+++ b/Source/FreeImage/MNGHelper.cpp
@@ -2,7 +2,7 @@
 // MNG / JNG helpers
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/MemoryIO.cpp
+++ b/Source/FreeImage/MemoryIO.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Ryan Rubley <ryan@lostreality.org> 
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/NNQuantizer.cpp
+++ b/Source/FreeImage/NNQuantizer.cpp
@@ -22,12 +22,12 @@
 // -------
 // January 2001: Adaptation of the Neural-Net Quantization Algorithm
 //               for the FreeImage 2 library
-//               Author: Hervé Drolon (drolon@infonie.fr)
+//               Author: HervÃ© Drolon (drolon@infonie.fr)
 // March 2004:   Adaptation for the FreeImage 3 library (port to big endian processors)
-//               Author: Hervé Drolon (drolon@infonie.fr)
+//               Author: HervÃ© Drolon (drolon@infonie.fr)
 // April 2004:   Algorithm rewritten as a C++ class. 
 //               Fixed a bug in the algorithm with handling of 4-byte boundary alignment.
-//               Author: Hervé Drolon (drolon@infonie.fr)
+//               Author: HervÃ© Drolon (drolon@infonie.fr)
 ///////////////////////////////////////////////////////////////////////
 
 #include "Quantizers.h"

--- a/Source/FreeImage/PixelAccess.cpp
+++ b/Source/FreeImage/PixelAccess.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Ryan Rubley (ryan@lostreality.org)
 // - Riley McNiff (rmcniff@marexgroup.com)
 //

--- a/Source/FreeImage/Plugin.cpp
+++ b/Source/FreeImage/Plugin.cpp
@@ -6,7 +6,7 @@
 // - Rui Lopes (ruiglopes@yahoo.com)
 // - Detlev Vendt (detlev.vendt@brillit.de)
 // - Petr Pytelka (pyta@lightcomp.com)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginBMP.cpp
+++ b/Source/FreeImage/PluginBMP.cpp
@@ -5,7 +5,7 @@
 // - Floris van den Berg (flvdberg@wxs.nl)
 // - Markus Loibl (markus.loibl@epost.de)
 // - Martin Weber (martweb@gmx.net)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Michal Novotny (michal@etc.cz)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //

--- a/Source/FreeImage/PluginDDS.cpp
+++ b/Source/FreeImage/PluginDDS.cpp
@@ -2,9 +2,9 @@
 // DDS Loader
 //
 // Design and implementation by
-// - Volker Gärtner (volkerg@gmx.at)
+// - Volker GÃ¤rtner (volkerg@gmx.at)
 // - Sherman Wilcox
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginEXR.cpp
+++ b/Source/FreeImage/PluginEXR.cpp
@@ -2,7 +2,7 @@
 // EXR Loader and writer
 //
 // Design and implementation by 
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/PluginG3.cpp
+++ b/Source/FreeImage/PluginG3.cpp
@@ -2,7 +2,7 @@
 // G3 Fax Loader
 //
 // Design and implementation by
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 // - Petr Pytelka (pyta@lightcomp.com)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/PluginICO.cpp
+++ b/Source/FreeImage/PluginICO.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginIFF.cpp
+++ b/Source/FreeImage/PluginIFF.cpp
@@ -5,7 +5,7 @@
 // - Floris van den Berg (flvdberg@wxs.nl)
 // - Mark Sibly (marksibly@blitzbasic.com)
 // - Aaron Shumate (trek@startreker.com)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginJPEG.cpp
+++ b/Source/FreeImage/PluginJPEG.cpp
@@ -7,7 +7,7 @@
 // - Jan L. Nauta (jln@magentammt.com)
 // - Markus Loibl (markus.loibl@epost.de)
 // - Karl-Heinz Bussian (khbussian@moss.de)
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 // - Jascha Wetzel (jascha@mainia.de)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //

--- a/Source/FreeImage/PluginPCX.cpp
+++ b/Source/FreeImage/PluginPCX.cpp
@@ -5,7 +5,7 @@
 // - Floris van den Berg (flvdberg@wxs.nl)
 // - Jani Kajala (janik@remedy.fi)
 // - Markus Loibl (markus.loibl@epost.de)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Juergen Riecker (j.riecker@gmx.de)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/PluginPNM.cpp
+++ b/Source/FreeImage/PluginPNM.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginRAS.cpp
+++ b/Source/FreeImage/PluginRAS.cpp
@@ -2,7 +2,7 @@
 // Sun rasterfile Loader
 //
 // Design and implementation by 
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginRAW.cpp
+++ b/Source/FreeImage/PluginRAW.cpp
@@ -2,7 +2,7 @@
 // RAW camera image loader
 //
 // Design and implementation by 
-// - Herv� Drolon (drolon@infonie.fr)
+// - Hervé Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/PluginWBMP.cpp
+++ b/Source/FreeImage/PluginWBMP.cpp
@@ -2,7 +2,7 @@
 // Wireless Bitmap Format Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //
@@ -32,10 +32,10 @@
 // ------------------------
 // The WBMP format is configured according to a type field value (TypeField below),
 // which maps to all relevant image encoding information, such as:
-// · Pixel organisation and encoding
-// · Palette organisation and encoding
-// · Compression characteristics
-// · Animation encoding
+// Â· Pixel organisation and encoding
+// Â· Palette organisation and encoding
+// Â· Compression characteristics
+// Â· Animation encoding
 // For each TypeField value, all relevant image characteristics are 
 // fully specified as part of the WAP documentation.
 // Currently, a simple compact, monochrome image format is defined

--- a/Source/FreeImage/PluginXBM.cpp
+++ b/Source/FreeImage/PluginXBM.cpp
@@ -2,7 +2,7 @@
 // XBM Loader
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 // part of the code adapted from the netPBM package (xbmtopbm.c)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/PluginXPM.cpp
+++ b/Source/FreeImage/PluginXPM.cpp
@@ -25,7 +25,7 @@
 // ------------------------
 // Initial design and implementation by
 // - Karl-Heinz Bussian (khbussian@moss.de)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // Completely rewritten from scratch by Ryan Rubley (ryan@lostreality.org)
 // in order to address the following major fixes:
 // * Supports any number of chars per pixel (not just 1 or 2)

--- a/Source/FreeImage/TIFFLogLuv.cpp
+++ b/Source/FreeImage/TIFFLogLuv.cpp
@@ -2,7 +2,7 @@
 // XYZ to RGB TIFF conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/ToneMapping.cpp
+++ b/Source/FreeImage/ToneMapping.cpp
@@ -2,7 +2,7 @@
 // Tone mapping operators
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/WuQuantizer.cpp
+++ b/Source/FreeImage/WuQuantizer.cpp
@@ -25,9 +25,9 @@
 // -------
 // July 2000:  C++ Implementation of Wu's Color Quantizer
 //             and adaptation for the FreeImage 2 Library
-//             Author: Hervé Drolon (drolon@infonie.fr)
+//             Author: HervÃ© Drolon (drolon@infonie.fr)
 // March 2004: Adaptation for the FreeImage 3 library (port to big endian processors)
-//             Author: Hervé Drolon (drolon@infonie.fr)
+//             Author: HervÃ© Drolon (drolon@infonie.fr)
 ///////////////////////////////////////////////////////////////////////
 
 #include "Quantizers.h"

--- a/Source/FreeImage/tmoColorConvert.cpp
+++ b/Source/FreeImage/tmoColorConvert.cpp
@@ -2,7 +2,7 @@
 // High Dynamic Range bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImage/tmoDrago03.cpp
+++ b/Source/FreeImage/tmoDrago03.cpp
@@ -2,7 +2,7 @@
 // Tone mapping operator (Drago, 2003)
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -40,7 +40,7 @@ biasFunction(const double b, const double x) {
 }
 
 /**
-Padé approximation of log(x + 1)
+PadÃ© approximation of log(x + 1)
 x(6+x)/(6+4x) good if x < 1
 x*(6 + 0.7662x)/(5.9897 + 3.7658x) between 1 and 2
 See http://www.nezumi.demon.co.uk/consult/logx.htm
@@ -94,7 +94,7 @@ ToneMappingDrago03(FIBITMAP *dib, const float maxLum, const float avgLum, float 
 
 	/**
 	Normal tone mapping of every pixel
-	further acceleration is obtained by a Padé approximation of log(x + 1)
+	further acceleration is obtained by a PadÃ© approximation of log(x + 1)
 	*/
 	BYTE *bits = (BYTE*)FreeImage_GetBits(dib);
 	for(y = 0; y < height; y++) {
@@ -121,7 +121,7 @@ ToneMappingDrago03(FIBITMAP *dib, const float maxLum, const float avgLum, float 
 	/**
 	fast tone mapping
 	split the image into 3x3 pixel tiles and perform the computation for each group of 9 pixels
-	further acceleration is obtained by a Padé approximation of log(x + 1)
+	further acceleration is obtained by a PadÃ© approximation of log(x + 1)
 	=> produce artifacts and not so faster, so the code has been disabled
 	*/
 #define PIXEL(x, y)	image[y*fpitch + x].red

--- a/Source/FreeImage/tmoFattal02.cpp
+++ b/Source/FreeImage/tmoFattal02.cpp
@@ -2,7 +2,7 @@
 // Tone mapping operator (Fattal, 2002)
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImage/tmoReinhard05.cpp
+++ b/Source/FreeImage/tmoReinhard05.cpp
@@ -2,7 +2,7 @@
 // Tone mapping operator (Reinhard, 2005)
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //
 // This file is part of FreeImage 3
@@ -30,7 +30,7 @@
 // [1] Erik Reinhard and Kate Devlin, 'Dynamic Range Reduction Inspired by Photoreceptor Physiology', 
 //     IEEE Transactions on Visualization and Computer Graphics, 11(1), Jan/Feb 2005. 
 // [2] Erik Reinhard, 'Parameter estimation for photographic tone reproduction',
-//     Journal of Graphics Tools, vol. 7, no. 1, pp. 45–51, 2003.
+//     Journal of Graphics Tools, vol. 7, no. 1, pp. 45Â–51, 2003.
 // ----------------------------------------------------------
 
 /**

--- a/Source/FreeImageToolkit/BSplineRotate.cpp
+++ b/Source/FreeImageToolkit/BSplineRotate.cpp
@@ -2,9 +2,9 @@
 // Bitmap rotation using B-Splines
 //
 // Design and implementation by
-// - Philippe Thévenaz (philippe.thevenaz@epfl.ch)
+// - Philippe ThÃ©venaz (philippe.thevenaz@epfl.ch)
 // Adaptation for FreeImage by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -25,7 +25,7 @@
 ==========================================================
 This code was taken and adapted from the following reference : 
 
-[1] Philippe Thévenaz, Spline interpolation, a C source code 
+[1] Philippe ThÃ©venaz, Spline interpolation, a C source code 
 implementation. http://bigwww.epfl.ch/thevenaz/
 
 It implements ideas described in the following papers : 

--- a/Source/FreeImageToolkit/Channels.cpp
+++ b/Source/FreeImageToolkit/Channels.cpp
@@ -2,7 +2,7 @@
 // Channel processing support
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImageToolkit/ClassicRotate.cpp
+++ b/Source/FreeImageToolkit/ClassicRotate.cpp
@@ -2,7 +2,7 @@
 // Bitmap rotation by means of 3 shears.
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Thorsten Radde (support@IdealSoftware.com)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //

--- a/Source/FreeImageToolkit/Colors.cpp
+++ b/Source/FreeImageToolkit/Colors.cpp
@@ -2,7 +2,7 @@
 // Color manipulation routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Carsten Klein (c.klein@datagis.com)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 //

--- a/Source/FreeImageToolkit/CopyPaste.cpp
+++ b/Source/FreeImageToolkit/CopyPaste.cpp
@@ -3,7 +3,7 @@
 //
 // - Floris van den Berg (flvdberg@wxs.nl)
 // - Alexander Dymerets (sashad@te.net.ua)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Manfred Tausch (manfred.tausch@t-online.de)
 // - Riley McNiff (rmcniff@marexgroup.com)
 // - Carsten Klein (cklein05@users.sourceforge.net)

--- a/Source/FreeImageToolkit/Display.cpp
+++ b/Source/FreeImageToolkit/Display.cpp
@@ -2,7 +2,7 @@
 // Display routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImageToolkit/Filters.h
+++ b/Source/FreeImageToolkit/Filters.h
@@ -2,7 +2,7 @@
 // Upsampling / downsampling filters
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/FreeImageToolkit/Flip.cpp
+++ b/Source/FreeImageToolkit/Flip.cpp
@@ -3,7 +3,7 @@
 //
 // Design and implementation by
 // - Floris van den Berg (flvdberg@wxs.nl)
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Jim Keir (jimkeir@users.sourceforge.net)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImageToolkit/MultigridPoissonSolver.cpp
+++ b/Source/FreeImageToolkit/MultigridPoissonSolver.cpp
@@ -2,7 +2,7 @@
 // Poisson solver based on a full multigrid algorithm
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // Reference:
 // PRESS, W. H., TEUKOLSKY, S. A., VETTERLING, W. T., AND FLANNERY, B. P.
 // 1992. Numerical Recipes in C: The Art of Scientific Computing, 2nd ed. Cambridge University Press.
@@ -292,7 +292,7 @@ static void fmg_addint(FIBITMAP *UF, FIBITMAP *UC, FIBITMAP *RES, int nf) {
 
 /**
 Full Multigrid Algorithm for solution of linear elliptic equation, here the model problem (19.0.6).
-On input u[0..n-1][0..n-1] contains the right-hand side ñ, while on output it returns the solution.
+On input u[0..n-1][0..n-1] contains the right-hand side Ã±, while on output it returns the solution.
 The dimension n must be of the form 2^j + 1 for some integer j. (j is actually the number of
 grid levels used in the solution, called ng below.) ncycle is the number of V-cycles to be
 used at each level.

--- a/Source/FreeImageToolkit/Rescale.cpp
+++ b/Source/FreeImageToolkit/Rescale.cpp
@@ -2,7 +2,7 @@
 // Upsampling / downsampling routine
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Carsten Klein (cklein05@users.sourceforge.net)
 //
 // This file is part of FreeImage 3

--- a/Source/FreeImageToolkit/Resize.cpp
+++ b/Source/FreeImageToolkit/Resize.cpp
@@ -2,7 +2,7 @@
 // Upsampling / downsampling classes
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Detlev Vendt (detlev.vendt@brillit.de)
 // - Carsten Klein (cklein05@users.sourceforge.net)
 //

--- a/Source/FreeImageToolkit/Resize.h
+++ b/Source/FreeImageToolkit/Resize.h
@@ -2,7 +2,7 @@
 // Upsampling / downsampling classes
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Detlev Vendt (detlev.vendt@brillit.de)
 // - Carsten Klein (cklein05@users.sourceforge.net)
 //

--- a/Source/Metadata/Exif.cpp
+++ b/Source/Metadata/Exif.cpp
@@ -3,7 +3,7 @@
 // Exif metadata model
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 // - Mihail Naydenov (mnaydenov@users.sourceforge.net)
 // - Garrick Meeker (garrickmeeker@users.sourceforge.net)
 //
@@ -1031,12 +1031,12 @@ RotateExif(FIBITMAP **dib) {
 		if((tag != NULL) && (FreeImage_GetTagID(tag) == TAG_ORIENTATION)) {
 			const WORD orientation = *((WORD *)FreeImage_GetTagValue(tag));
 			switch (orientation) {
-				case 1:		// "top, left side" => 0°
+				case 1:		// "top, left side" => 0Â°
 					break;
 				case 2:		// "top, right side" => flip left-right
 					FreeImage_FlipHorizontal(*dib);
 					break;
-				case 3:		// "bottom, right side" => -180°
+				case 3:		// "bottom, right side" => -180Â°
 					rotated = FreeImage_Rotate(*dib, 180);
 					FreeImage_Unload(*dib);
 					*dib = rotated;
@@ -1044,24 +1044,24 @@ RotateExif(FIBITMAP **dib) {
 				case 4:		// "bottom, left side" => flip up-down
 					FreeImage_FlipVertical(*dib);
 					break;
-				case 5:		// "left side, top" => +90° + flip up-down
+				case 5:		// "left side, top" => +90Â° + flip up-down
 					rotated = FreeImage_Rotate(*dib, 90);
 					FreeImage_Unload(*dib);
 					*dib = rotated;
 					FreeImage_FlipVertical(*dib);
 					break;
-				case 6:		// "right side, top" => -90°
+				case 6:		// "right side, top" => -90Â°
 					rotated = FreeImage_Rotate(*dib, -90);
 					FreeImage_Unload(*dib);
 					*dib = rotated;
 					break;
-				case 7:		// "right side, bottom" => -90° + flip up-down
+				case 7:		// "right side, bottom" => -90Â° + flip up-down
 					rotated = FreeImage_Rotate(*dib, -90);
 					FreeImage_Unload(*dib);
 					*dib = rotated;
 					FreeImage_FlipVertical(*dib);
 					break;
-				case 8:		// "left side, bottom" => +90°
+				case 8:		// "left side, bottom" => +90Â°
 					rotated = FreeImage_Rotate(*dib, 90);
 					FreeImage_Unload(*dib);
 					*dib = rotated;

--- a/Source/Metadata/FIRational.cpp
+++ b/Source/Metadata/FIRational.cpp
@@ -2,7 +2,7 @@
 // Helper class for rational numbers
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Metadata/FIRational.h
+++ b/Source/Metadata/FIRational.h
@@ -2,7 +2,7 @@
 // Helper class for rational numbers
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Metadata/FreeImageTag.cpp
+++ b/Source/Metadata/FreeImageTag.cpp
@@ -2,7 +2,7 @@
 // Tag manipulation functions
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Metadata/FreeImageTag.h
+++ b/Source/Metadata/FreeImageTag.h
@@ -2,7 +2,7 @@
 // Tag manipulation functions
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //
@@ -322,7 +322,7 @@ typedef struct tagTagInfo {
 
 
 /**
-Class to hold tag information (based on Meyers’ Singleton).<br>
+Class to hold tag information (based on MeyersÂ’ Singleton).<br>
 
 Sample usage :<br>
 <code>

--- a/Source/Metadata/IPTC.cpp
+++ b/Source/Metadata/IPTC.cpp
@@ -2,7 +2,7 @@
 // Metadata functions implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Metadata/TagConversion.cpp
+++ b/Source/Metadata/TagConversion.cpp
@@ -2,7 +2,7 @@
 // Tag to string conversion functions
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Metadata/TagLib.cpp
+++ b/Source/Metadata/TagLib.cpp
@@ -2,7 +2,7 @@
 // Tag library
 //
 // Design and implementation by
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 //
 // This file is part of FreeImage 3
 //

--- a/Source/Quantizers.h
+++ b/Source/Quantizers.h
@@ -2,7 +2,7 @@
 // Quantizer objects and functions
 //
 // Design and implementation by:
-// - Hervé Drolon <drolon@infonie.fr>
+// - HervÃ© Drolon <drolon@infonie.fr>
 // - Carsten Klein (cklein05@users.sourceforge.net)
 //
 // This file is part of FreeImage 3

--- a/Source/ToneMapping.h
+++ b/Source/ToneMapping.h
@@ -2,7 +2,7 @@
 // High Dynamic Range bitmap conversion routines
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/MainTestSuite.cpp
+++ b/TestAPI/MainTestSuite.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/TestSuite.h
+++ b/TestAPI/TestSuite.h
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testChannels.cpp
+++ b/TestAPI/testChannels.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testHeaderOnly.cpp
+++ b/TestAPI/testHeaderOnly.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testImageType.cpp
+++ b/TestAPI/testImageType.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testJPEG.cpp
+++ b/TestAPI/testJPEG.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testMPage.cpp
+++ b/TestAPI/testMPage.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testMPageMemory.cpp
+++ b/TestAPI/testMPageMemory.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testMPageStream.cpp
+++ b/TestAPI/testMPageStream.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testMemIO.cpp
+++ b/TestAPI/testMemIO.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testPlugins.cpp
+++ b/TestAPI/testPlugins.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testThumbnail.cpp
+++ b/TestAPI/testThumbnail.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/TestAPI/testTools.cpp
+++ b/TestAPI/testTools.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -34,7 +34,7 @@
   <li> evaluate image compression 
   <li> evaluate filter properties 
   <li> evaluate the quality of resampling algorithms 
-  <li> adjust gamma correction - at the proper gamma setting, the møires should be minimized 
+  <li> adjust gamma correction - at the proper gamma setting, the mÃ¸ires should be minimized 
   </ul>
   Reference: 
   [1] Ken Turkowski, Open Source Repository. [Online] http://www.worldserver.com/turk/opensource/

--- a/TestAPI/testWrappedBuffer.cpp
+++ b/TestAPI/testWrappedBuffer.cpp
@@ -2,7 +2,7 @@
 // FreeImage 3 Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/Delphi/WhatsNew_Delphi.txt
+++ b/Wrapper/Delphi/WhatsNew_Delphi.txt
@@ -19,7 +19,7 @@ September 17, 2015
 May 5, 2014
 + [Lorenzo Monti] updated wrapper for FreeImage 3.16.1
 + [Lorenzo Monti] added preprocessor tests for Delphi XE2..XE6
-+ [Lorenzo Monti] merged changes for OSX compatibility (submitted by Maurício)
++ [Lorenzo Monti] merged changes for OSX compatibility (submitted by MaurÃ­cio)
 
 December 8, 2012
 + [Lorenzo Monti] updated wrapper for FreeImage 3.15.4
@@ -63,7 +63,7 @@ July 14, 2010
 ! [Lorenzo Monti] changed FreeBitmap.pas, FreeUtils.pas and TargaImage.pas to reflect changes in the FreeImage.pas unit
 
 July 17, 2006
-+ [Hervé Drolon] added FIF_FAXG3 and FIF_SGI definitions, added FreeImage_MakeThumbnail definition. 
++ [HervÃ© Drolon] added FIF_FAXG3 and FIF_SGI definitions, added FreeImage_MakeThumbnail definition. 
 
 January 20, 2006
 ! [Anatoliy Pulyaevskiy] updated WinBitmap demo
@@ -121,7 +121,7 @@ January 7, 2004
 + [Tommy] added TargaImage unit
 
 October 28, 2003
-+ [Peter Byström] updated the wrapper for FreeImage 3.0.2
++ [Peter BystrÃ¶m] updated the wrapper for FreeImage 3.0.2
 
 August 9, 2003
 + [Simon Beavis] added a wrapper for FreeImage 2.6.1

--- a/Wrapper/FreeImagePlus/FreeImagePlus.h
+++ b/Wrapper/FreeImagePlus/FreeImagePlus.h
@@ -2,7 +2,7 @@
 // FreeImagePlus 3
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -70,7 +70,7 @@
 
 /** Abstract base class for all objects used by the library.
 	@version FreeImage 3
-	@author Hervé Drolon
+	@author HervÃ© Drolon
 */
 
 class FIP_API fipObject
@@ -97,7 +97,7 @@ class fipTag;
 	fipImage encapsulates the FIBITMAP format. It relies on the FreeImage library, especially for 
 	loading / saving images and for bit depth conversion.
 	@version FreeImage 3
-	@author Hervé Drolon
+	@author HervÃ© Drolon
 */
 
 class FIP_API fipImage : public fipObject
@@ -570,7 +570,7 @@ public:
 	*/
 	BYTE* accessPixels() const;
 
-	/** @brief Returns a pointer to the start of the given scanline in the bitmap’s data-bits.
+	/** @brief Returns a pointer to the start of the given scanline in the bitmapÂ’s data-bits.
 		This pointer can be cast according to the result returned by getImageType.<br>
 		Use this function with getScanWidth to iterates through the pixels. 
 		@see FreeImage_GetScanLine, FreeImage documentation
@@ -780,14 +780,14 @@ public:
 	unsigned getTransparencyCount() const;
 
 	/**
-	8-bit transparency : get the bitmap’s transparency table.
-	@return Returns a pointer to the bitmap’s transparency table.
+	8-bit transparency : get the bitmapÂ’s transparency table.
+	@return Returns a pointer to the bitmapÂ’s transparency table.
 	@see FreeImage_GetTransparencyTable
 	*/
 	BYTE* getTransparencyTable() const;
 
 	/** 
-	8-bit transparency : set the bitmap’s transparency table.
+	8-bit transparency : set the bitmapÂ’s transparency table.
 	@see FreeImage_SetTransparencyTable
 	*/
 	void setTransparencyTable(BYTE *table, int count);
@@ -1079,7 +1079,7 @@ public:
 	<li>Capture a window (HWND) and convert it to an image
 	</ul>
 	@version FreeImage 3
-	@author Hervé Drolon
+	@author HervÃ© Drolon
 */
 #ifdef _WIN32
 
@@ -1255,7 +1255,7 @@ protected:
 	
 	fipMemoryIO is a class that allows you to load / save images from / to a memory stream.
 	@version FreeImage 3
-	@author Hervé Drolon
+	@author HervÃ© Drolon
 */
 class FIP_API fipMemoryIO : public fipObject
 {

--- a/Wrapper/FreeImagePlus/src/FreeImagePlus.cpp
+++ b/Wrapper/FreeImagePlus/src/FreeImagePlus.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus.cpp : Defines the entry point for the DLL application.
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipImage.cpp
+++ b/Wrapper/FreeImagePlus/src/fipImage.cpp
@@ -2,7 +2,7 @@
 // fipImage class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipMemoryIO.cpp
+++ b/Wrapper/FreeImagePlus/src/fipMemoryIO.cpp
@@ -2,7 +2,7 @@
 // fipMemoryIO class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipMetadataFind.cpp
+++ b/Wrapper/FreeImagePlus/src/fipMetadataFind.cpp
@@ -2,7 +2,7 @@
 // fipMetadataFind class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipMultiPage.cpp
+++ b/Wrapper/FreeImagePlus/src/fipMultiPage.cpp
@@ -2,7 +2,7 @@
 // fipMultiPage class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipTag.cpp
+++ b/Wrapper/FreeImagePlus/src/fipTag.cpp
@@ -2,7 +2,7 @@
 // fipTag class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/src/fipWinImage.cpp
+++ b/Wrapper/FreeImagePlus/src/fipWinImage.cpp
@@ -2,7 +2,7 @@
 // fipWinImage class implementation
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTest.cpp
+++ b/Wrapper/FreeImagePlus/test/fipTest.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTest.h
+++ b/Wrapper/FreeImagePlus/test/fipTest.h
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTestMPage.cpp
+++ b/Wrapper/FreeImagePlus/test/fipTestMPage.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTestMPageMemory.cpp
+++ b/Wrapper/FreeImagePlus/test/fipTestMPageMemory.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTestMPageStream.cpp
+++ b/Wrapper/FreeImagePlus/test/fipTestMPageStream.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //

--- a/Wrapper/FreeImagePlus/test/fipTestMemIO.cpp
+++ b/Wrapper/FreeImagePlus/test/fipTestMemIO.cpp
@@ -2,7 +2,7 @@
 // FreeImagePlus Test Script
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - HervÃ© Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //


### PR DESCRIPTION
101 files carried the "Hervé Drolon" author credit as raw ISO-8859-1 bytes rather than UTF-8, rendering as "Herv?" or a mangled replacement character depending on the viewer/editor, despite the repo otherwise being treated as UTF-8 everywhere (GitHub, git, most editors).

Converted each affected file's encoding from ISO-8859-1 to UTF-8. Byte-for-byte content is otherwise identical - these files have no other non-ASCII bytes.

5 files (PluginEXR.cpp, PluginG3.cpp, PluginJPEG.cpp, PluginRAW.cpp) had already been corrupted to the UTF-8 replacement character (U+FFFD) by an editing tool earlier in the repo's history - restored "é" directly for those instead.

Tested: every touched file is now valid UTF-8, line endings are unchanged (checked file-by-file against HEAD), only the one credit line differs per file, and the full test suite passes.