### PR TITLE
Fix mojibake left by the Hervé Drolon UTF-8 conversion

### DIFF
--- a/Source/FreeImage/tmoReinhard05.cpp
+++ b/Source/FreeImage/tmoReinhard05.cpp
@@ -30,7 +30,7 @@
 // [1] Erik Reinhard and Kate Devlin, 'Dynamic Range Reduction Inspired by Photoreceptor Physiology', 
 //     IEEE Transactions on Visualization and Computer Graphics, 11(1), Jan/Feb 2005. 
 // [2] Erik Reinhard, 'Parameter estimation for photographic tone reproduction',
-//     Journal of Graphics Tools, vol. 7, no. 1, pp. 4551, 2003.
+//     Journal of Graphics Tools, vol. 7, no. 1, pp. 45-51, 2003.
 // ----------------------------------------------------------
 
 /**

--- a/Source/Metadata/FreeImageTag.h
+++ b/Source/Metadata/FreeImageTag.h
@@ -322,7 +322,7 @@ typedef struct tagTagInfo {
 
 
 /**
-Class to hold tag information (based on Meyers Singleton).<br>
+Class to hold tag information (based on Meyers' Singleton).<br>
 
 Sample usage :<br>
 <code>

--- a/Wrapper/FreeImagePlus/FreeImagePlus.h
+++ b/Wrapper/FreeImagePlus/FreeImagePlus.h
@@ -570,7 +570,7 @@ public:
 	*/
 	BYTE* accessPixels() const;
 
-	/** @brief Returns a pointer to the start of the given scanline in the bitmaps data-bits.
+	/** @brief Returns a pointer to the start of the given scanline in the bitmap's data-bits.
 		This pointer can be cast according to the result returned by getImageType.<br>
 		Use this function with getScanWidth to iterates through the pixels. 
 		@see FreeImage_GetScanLine, FreeImage documentation
@@ -780,14 +780,14 @@ public:
 	unsigned getTransparencyCount() const;
 
 	/**
-	8-bit transparency : get the bitmaps transparency table.
-	@return Returns a pointer to the bitmaps transparency table.
+	8-bit transparency : get the bitmap's transparency table.
+	@return Returns a pointer to the bitmap's transparency table.
 	@see FreeImage_GetTransparencyTable
 	*/
 	BYTE* getTransparencyTable() const;
 
 	/** 
-	8-bit transparency : set the bitmaps transparency table.
+	8-bit transparency : set the bitmap's transparency table.
 	@see FreeImage_SetTransparencyTable
 	*/
 	void setTransparencyTable(BYTE *table, int count);


### PR DESCRIPTION
## Summary
- Fixes mojibake introduced by #71: that conversion assumed the whole codebase was ISO-8859-1, but a few files actually used Windows-1252, which differs from ISO-8859-1 in the 0x80–0x9F byte range (smart quotes, en/em dashes, etc). Decoding those bytes as ISO-8859-1 turned them into invisible Unicode C1 control characters instead of the intended punctuation.
- @thbeu's review on #71 caught two: an en-dash in `tmoReinhard05.cpp` and an apostrophe in `FreeImagePlus.h` that had silently vanished, replaced by an invisible control character.
- A repo-wide scan for C1 control characters (U+0080–U+009F) across all tracked files turned up a third file with the same issue that wasn't flagged in review: `Source/Metadata/FreeImageTag.h`.
- Per @thbeu's suggested diff, normalized all three to plain ASCII (`-` and `'`) rather than restoring the original curly-quote/en-dash characters.

## Test plan
- [x] Re-extracted the pre-#71 blob for each file and confirmed it decodes cleanly as cp1252 with no other non-ASCII bytes beyond the already-correct "Hervé" `é` and the newly-identified `–`/`'` bytes.
- [x] Confirmed line endings (LF for two files, CRLF for `FreeImagePlus.h`) are unchanged from current master.
- [x] Repo-wide scan (`git ls-files` + decode as UTF-8, check for any U+0080–U+009F codepoints) now returns zero hits.