### PR TITLE
Fix heap-use-after-free reading ICC profile from TIFF with ExifIFD

### DIFF
--- a/Source/FreeImage/PluginTIFF.cpp
+++ b/Source/FreeImage/PluginTIFF.cpp
@@ -2316,6 +2316,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 
 		// copy ICC profile data (must be done after FreeImage_Allocate)
 
+		// ReadMetadata() -> tiff_read_exif_profile() may call TIFFReadEXIFDirectory()
+		// when the file has an ExifIFD, which switches libtiff to a different IFD and
+		// back, invalidating the iccBuf pointer fetched above (it points into libtiff's
+		// per-directory field storage). Re-fetch it now that we're back on the main IFD.
+		if (iccBuf) {
+			TIFFGetField(tif, TIFFTAG_ICCPROFILE, &iccSize, &iccBuf);
+		}
 		FreeImage_CreateICCProfile(dib, iccBuf, iccSize);
 		if (photometric == PHOTOMETRIC_SEPARATED) {
 			if (asCMYK) {


### PR DESCRIPTION
Fixes #27.

`TIFFGetField(tif, TIFFTAG_ICCPROFILE, ...)`-- `Load()`, but `ReadMetadata()` → `tiff_read_exif_profile()` 
can call `TIFFReadEXIFDirectory()` when the file has an ExifIFD, 

which switches libtiff to that directory and back via `TIFFReadCustomDirectory` → `TIFFFreeDirectory` — 

freeing/reallocating the per-directory field storage the original `iccBuf` pointer pointed into. 

By the time `FreeImage_CreateICCProfile(dib, iccBuf, iccSize)` ran, `iccBuf` could be reading freed memory: correct data, garbage, or a crash depending on what reused the block.

Diagnosed and reported by @eyec-dirk in #27, with a working fix (re-query `TIFFGetField` after `ReadMetadata`) already included in their report — applied as-is.
