### PR TITLE
Drop LibRaw's *_ph.cpp placeholder files from the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,11 +565,9 @@ if(BUILD_LIBRAWLITE)
         ./Source/LibRawLite/src/postprocessing/dcraw_process.cpp
         ./Source/LibRawLite/src/postprocessing/mem_image.cpp
         ./Source/LibRawLite/src/postprocessing/postprocessing_aux.cpp
-        ./Source/LibRawLite/src/postprocessing/postprocessing_ph.cpp
         ./Source/LibRawLite/src/postprocessing/postprocessing_utils.cpp
         ./Source/LibRawLite/src/postprocessing/postprocessing_utils_dcrdefs.cpp
         ./Source/LibRawLite/src/preprocessing/ext_preprocess.cpp
-        ./Source/LibRawLite/src/preprocessing/preprocessing_ph.cpp
         ./Source/LibRawLite/src/preprocessing/raw2image.cpp
         ./Source/LibRawLite/src/preprocessing/subtract_black.cpp
         ./Source/LibRawLite/src/tables/cameralist.cpp
@@ -586,7 +584,6 @@ if(BUILD_LIBRAWLITE)
         ./Source/LibRawLite/src/write/apply_profile.cpp
         ./Source/LibRawLite/src/write/file_write.cpp
         ./Source/LibRawLite/src/write/tiff_writer.cpp
-        ./Source/LibRawLite/src/write/write_ph.cpp
         ./Source/LibRawLite/src/x3f/x3f_parse_process.cpp
         ./Source/LibRawLite/src/x3f/x3f_utils_patched.cpp
     )


### PR DESCRIPTION
## Summary
While testing \`-DBUILD_SHARED_LIBS=ON\` (raised in #28) combined with \`-DBUILD_LIBRAWLITE=ON\`,

 found the same class of bug already fixed for OpenEXR (#77): \`postprocessing_ph.cpp\`, \`preprocessing_ph.cpp\`, and \`write_ph.cpp\` are explicitly labeled by their own file header as *"Placeholder functions to build LibRaw w/o postprocessing tools"* — \`dcraw_process()\` returns \`LIBRAW_NOT_IMPLEMENTED\`, 

\`dcraw_make_mem_image()\`/\`dcraw_make_mem_thumb()\` return \`NULL\`,

 everything else is an empty no-op. 

They're an alternate, either/or upstream build configuration (a stripped-down LibRaw that doesn't actually develop raw sensor data), never meant to be compiled alongside the real implementation files \`PluginRAW.cpp\` actually needs.

Harmless in a static-only build (13 duplicate symbols sit inertly unresolved in the archive), but breaks any shared-library link with "duplicate symbol" for all 13.

