### PR TITLE
Port 3 fixes from the WinMerge/freeimage fork

### DIFF
--- a/Source/FreeImage/Conversion32.cpp
+++ b/Source/FreeImage/Conversion32.cpp
@@ -263,7 +263,10 @@ FreeImage_ConvertTo32Bits(FIBITMAP *dib) {
 			case 16:
 			{
 				for (int rows = 0; rows < height; rows++) {
-					if ((FreeImage_GetRedMask(dib) == FI16_565_RED_MASK) && (FreeImage_GetGreenMask(dib) == FI16_565_GREEN_MASK) && (FreeImage_GetBlueMask(dib) == FI16_565_BLUE_MASK)) {
+					// FI16_565_BLUE_MASK == FI16_555_BLUE_MASK (0x001F), so it can't distinguish
+					// the two formats; some 16-bit producers also don't set the red mask
+					// reliably. The green mask (0x07E0 vs 0x03E0) is the only field that does.
+					if (FreeImage_GetGreenMask(dib) == FI16_565_GREEN_MASK) {
 						FreeImage_ConvertLine16To32_565(FreeImage_GetScanLine(new_dib, rows), FreeImage_GetScanLine(dib, rows), width);
 					} else {
 						// includes case where all the masks are 0

--- a/Source/FreeImage/PluginDDS.cpp
+++ b/Source/FreeImage/PluginDDS.cpp
@@ -690,20 +690,22 @@ LoadDXT_Helper(FreeImageIO *io, fi_handle handle, FIBITMAP *dib, int width, int 
 		return;
 	}
 
+	const int widthTrimmed = (int) width & ~3;
+	const int heightTrimmed = (int) height & ~3;
 	const int widthRest = (int) width & 3;
 	const int heightRest = (int) height & 3;
 	const int inputLine = (width + 3) / 4;
 	int y = 0;
 
 	if (height >= 4) {
-		for (; y < height; y += 4) {
+		for (; y < heightTrimmed; y += 4) {
 			io->read_proc (input_buffer, sizeof(typename INFO::Block), inputLine, handle);
 			// TODO: probably need some endian work here
 			const BYTE *pbSrc = (BYTE *)input_buffer;
 			BYTE *pbDst = FreeImage_GetScanLine (dib, height - y - 1);
 
-			if (width >= 4) {
-				for (int x = 0; x < width; x += 4) {
+			if (widthTrimmed >= 4) {
+				for (int x = 0; x < widthTrimmed; x += 4) {
 					DecodeDXTBlock<DECODER>(pbDst, pbSrc, line, 4, 4);
 					pbSrc += INFO::bytesPerBlock;
 					pbDst += 16;	// 4 * 4;
@@ -720,8 +722,8 @@ LoadDXT_Helper(FreeImageIO *io, fi_handle handle, FIBITMAP *dib, int width, int 
 		const BYTE *pbSrc = (BYTE *)input_buffer;
 		BYTE *pbDst = FreeImage_GetScanLine (dib, height - y - 1);
 
-		if (width >= 4) {
-			for (int x = 0; x < width; x += 4) {
+		if (widthTrimmed >= 4) {
+			for (int x = 0; x < widthTrimmed; x += 4) {
 				DecodeDXTBlock<DECODER>(pbDst, pbSrc, line, 4, heightRest);
 				pbSrc += INFO::bytesPerBlock;
 				pbDst += 16;	// 4 * 4;
@@ -744,9 +746,12 @@ LoadDXT_Helper(FreeImageIO *io, fi_handle handle, FIBITMAP *dib, int width, int 
 */
 static FIBITMAP *
 LoadDXT(int decoder_type, const DDSURFACEDESC2 *desc, FreeImageIO *io, fi_handle handle) {
-	// get image size, rounded to 32-bit
-	int width = (int)desc->dwWidth & ~3;
-	int height = (int)desc->dwHeight & ~3;
+	// get image size - LoadDXT_Helper() handles non-multiple-of-4 dimensions
+	// itself (widthRest/heightRest), so don't truncate them away here: doing
+	// so silently cropped up to 3 pixels off the width/height of any DXT
+	// image whose declared dimensions weren't already a multiple of 4.
+	int width = (int)desc->dwWidth;
+	int height = (int)desc->dwHeight;
 
 	// allocate a 32-bit dib
 	FIBITMAP *dib = FreeImage_Allocate(width, height, 32, FI_RGBA_RED_MASK, FI_RGBA_GREEN_MASK, FI_RGBA_BLUE_MASK);

--- a/Source/Metadata/TagConversion.cpp
+++ b/Source/Metadata/TagConversion.cpp
@@ -37,7 +37,7 @@ Convert a tag to a C string
 static const char* 
 ConvertAnyTag(FITAG *tag) {
 	char format[MAX_TEXT_EXTENT];
-	static std::string buffer;
+	thread_local static std::string buffer;
 	DWORD i;
 
 	if(!tag)
@@ -260,7 +260,7 @@ Convert a Exif tag to a C string
 static const char* 
 ConvertExifTag(FITAG *tag) {
 	char format[MAX_TEXT_EXTENT];
-	static std::string buffer;
+	thread_local static std::string buffer;
 
 	if(!tag)
 		return NULL;
@@ -1003,7 +1003,7 @@ Convert a Exif GPS tag to a C string
 static const char* 
 ConvertExifGPSTag(FITAG *tag) {
 	char format[MAX_TEXT_EXTENT];
-	static std::string buffer;
+	thread_local static std::string buffer;
 
 	if(!tag)
 		return NULL;


### PR DESCRIPTION
Part of #46. Reviewed the WinMerge/freeimage fork's ~100 commits ahead of us; most are Visual Studio project-file churn (VS2015→2022 upgrades) that doesn't apply to our CMake-based build. These three are real, portable code fixes:

1. **Thread-safety**: `FreeImage_TagToString()` used plain `static std::string` buffers shared across threads → `thread_local`. ([WinMerge/freeimage@53cc1a4](https://github.com/WinMerge/freeimage/commit/53cc1a4efa6989552922c69c22a6e9f94f084736))
2. **RGB565 conversion**: `FreeImage_ConvertTo32Bits()`'s 16-bit path required red+green+blue masks to all match RGB565, but the blue mask is identical between RGB555/RGB565 (`0x001F`) and can never distinguish them — checking only the green mask (the one field that actually differs) fixes some 16-bit images converting via the wrong (555) path. ([WinMerge/freeimage@115b7d5](https://github.com/WinMerge/freeimage/commit/115b7d5c82bcf6597abbd3f9e53163544b0051c7))
3. **DDS cropping**: DXT-compressed DDS images with dimensions not a multiple of 4 were silently cropped by up to 3px per axis. Inspired by [WinMerge/freeimage@6f47890](https://github.com/WinMerge/freeimage/commit/6f478909d55e0d36d59c75e3967a0584f99565d7) ("DDS Image viewer is very weird"), rewritten for our current `PluginDDS.cpp` structure, which has diverged from what that commit was originally written against.

Skipped from the same review, with reasons: a `TagLib::instance()` singleton change (WinMerge/freeimage@52117fb) that trades away C++11's thread-safe magic-statics for an unsynchronized manual singleton — a workaround for an old Windows XP-era MSVC bug, would be a correctness regression on our modern toolchains; and a `libraw_datastream.cpp` move-semantics fix (WinMerge/freeimage@f5127ce) already superseded by LibRaw's own upstream code in the version we bundle.

## Test plan
- [x] Full `ctest` suite passes.
- [x] DDS fix verified with a real 15x15 DXT1 file (built via ImageMagick): loaded as 12x12 before, 15x15 after, zero ASan findings either way.
- [x] RGB565 fix verified against the actual `FI16_565_*`/`FI16_555_*` mask constants — blue masks are byte-identical (`0x001F`), confirming the blue-mask check was always uninformative.