### PR TITLE
Derive Windows FILEVERSION/PRODUCTVERSION from the git tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,52 @@
 cmake_minimum_required(VERSION 3.16)
-project(FreeImage VERSION 3.19.0 LANGUAGES C CXX)
+
+# Determine the version from the latest git tag (e.g. "3.19.12"), falling
+# back to a static default when building from a source archive without
+# .git history (or when git isn't installed). This has to run before
+# project() below, since its VERSION argument needs a literal
+# MAJOR.MINOR.PATCH at parse time - it can't be computed afterwards.
+set(FREEIMAGE_VERSION_FALLBACK 3.19.12)
+set(FREEIMAGE_VERSION_COMMITS 0)
+set(FREEIMAGE_VERSION_HASH "unknown")
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --long --match "[0-9]*.[0-9]*.[0-9]*"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE FREEIMAGE_GIT_DESCRIBE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE FREEIMAGE_GIT_DESCRIBE_RESULT
+    )
+    if(FREEIMAGE_GIT_DESCRIBE_RESULT EQUAL 0)
+        # e.g. "3.19.12-45-ge32af9e" -> tag 3.19.12, 45 commits past it, hash ge32af9e
+        string(REGEX MATCH "^([0-9]+\\.[0-9]+\\.[0-9]+)-([0-9]+)-(g[0-9a-f]+)$" _fi_ver_match "${FREEIMAGE_GIT_DESCRIBE}")
+        if(_fi_ver_match)
+            set(FREEIMAGE_VERSION ${CMAKE_MATCH_1})
+            set(FREEIMAGE_VERSION_COMMITS ${CMAKE_MATCH_2})
+            set(FREEIMAGE_VERSION_HASH ${CMAKE_MATCH_3})
+        endif()
+    endif()
+endif()
+if(NOT FREEIMAGE_VERSION)
+    set(FREEIMAGE_VERSION ${FREEIMAGE_VERSION_FALLBACK})
+endif()
+
+project(FreeImage VERSION ${FREEIMAGE_VERSION} LANGUAGES C CXX)
+
+set(FREEIMAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(FREEIMAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(FREEIMAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+# Human-readable version string: bare "3.19.12" exactly on a tag, or
+# "3.19.12+45.ge32af9e" (build metadata suffix, SemVer-style) in between.
+if(FREEIMAGE_VERSION_COMMITS EQUAL 0)
+    set(FREEIMAGE_VERSION_STRING "${FREEIMAGE_VERSION}")
+else()
+    set(FREEIMAGE_VERSION_STRING "${FREEIMAGE_VERSION}+${FREEIMAGE_VERSION_COMMITS}.${FREEIMAGE_VERSION_HASH}")
+endif()
+string(TIMESTAMP FREEIMAGE_COPYRIGHT_YEAR "%Y")
+message(STATUS "FreeImage version: ${FREEIMAGE_VERSION_STRING}")
 
 # Options for configuring the build
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
@@ -949,6 +996,19 @@ endif()
 include_directories(Source)
 include_directories(Source/Metadata)
 include_directories(Source/FreeImageToolkit)
+
+# Generate the Windows version resource from the git-tag-derived version
+# computed above, so FILEVERSION/PRODUCTVERSION (and the copyright year)
+# never need a manual bump again. Only meaningful on Windows, but
+# configure_file() is cheap enough to just always run it.
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/FreeImage.rc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/FreeImage.rc"
+    @ONLY
+)
+if(WIN32)
+    list(APPEND FreeImage_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/FreeImage.rc")
+endif()
 
 if(FREEIMAGE_STATIC)
     # Define the FreeImage library

--- a/FreeImage.rc
+++ b/FreeImage.rc
@@ -6,8 +6,8 @@
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,19,0,0
- PRODUCTVERSION 3,19,0,0
+ FILEVERSION 3,19,12,0
+ PRODUCTVERSION 3,19,12,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -25,14 +25,14 @@ BEGIN
             VALUE "Comments", "FreeImage is an Open Source library project for developers who would like to support popular graphics image formats like PNG, BMP, JPEG, TIFF and others as needed by today's multimedia applications.\0"
             VALUE "CompanyName", "FreeImage\0"
             VALUE "FileDescription", "FreeImage library\0"
-            VALUE "FileVersion", "3, 19, 0, 0\0"
+            VALUE "FileVersion", "3, 19, 12, 0\0"
             VALUE "InternalName", "FreeImage\0"
-            VALUE "LegalCopyright", "Copyright © 2003-2020 by FreeImage\0"
-            VALUE "LegalTrademarks", "See http://freeimage.sourceforge.net\0"
+            VALUE "LegalCopyright", "Copyright © 2003-2026 by FreeImage\0"
+            VALUE "LegalTrademarks", "See https://freeimage.sourceforge.net\0"
             VALUE "OriginalFilename", "FreeImage.dll\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "FreeImage\0"
-            VALUE "ProductVersion", "3, 19, 0, 0\0"
+            VALUE "ProductVersion", "3, 19, 12, 0\0"
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/FreeImage.rc.in
+++ b/FreeImage.rc.in
@@ -6,8 +6,8 @@
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,19,12,0
- PRODUCTVERSION 3,19,12,0
+ FILEVERSION @FREEIMAGE_VERSION_MAJOR@,@FREEIMAGE_VERSION_MINOR@,@FREEIMAGE_VERSION_PATCH@,@FREEIMAGE_VERSION_COMMITS@
+ PRODUCTVERSION @FREEIMAGE_VERSION_MAJOR@,@FREEIMAGE_VERSION_MINOR@,@FREEIMAGE_VERSION_PATCH@,@FREEIMAGE_VERSION_COMMITS@
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -24,15 +24,15 @@ BEGIN
         BEGIN
             VALUE "Comments", "FreeImage is an Open Source library project for developers who would like to support popular graphics image formats like PNG, BMP, JPEG, TIFF and others as needed by today's multimedia applications.\0"
             VALUE "CompanyName", "FreeImage\0"
-            VALUE "FileDescription", "FreeImagePlus library\0"
-            VALUE "FileVersion", "3, 19, 12, 0\0"
-            VALUE "InternalName", "FreeImagePlus\0"
-            VALUE "LegalCopyright", "Copyright © 2003-2026 by FreeImage\0"
+            VALUE "FileDescription", "FreeImage library\0"
+            VALUE "FileVersion", "@FREEIMAGE_VERSION_STRING@\0"
+            VALUE "InternalName", "FreeImage\0"
+            VALUE "LegalCopyright", "Copyright © 2003-@FREEIMAGE_COPYRIGHT_YEAR@ by FreeImage\0"
             VALUE "LegalTrademarks", "See https://freeimage.sourceforge.net\0"
-            VALUE "OriginalFilename", "FreeImagePlus.dll\0"
+            VALUE "OriginalFilename", "FreeImage.dll\0"
             VALUE "PrivateBuild", "\0"
-            VALUE "ProductName", "FreeImagePlus\0"
-            VALUE "ProductVersion", "3, 19, 12, 0\0"
+            VALUE "ProductName", "FreeImage\0"
+            VALUE "ProductVersion", "@FREEIMAGE_VERSION_STRING@\0"
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/Source/FreeImage.h
+++ b/Source/FreeImage.h
@@ -32,7 +32,7 @@
 
 #define FREEIMAGE_MAJOR_VERSION   3
 #define FREEIMAGE_MINOR_VERSION   19
-#define FREEIMAGE_RELEASE_SERIAL  0
+#define FREEIMAGE_RELEASE_SERIAL  12
 
 // Compiler options ---------------------------------------------------------
 

--- a/Wrapper/FreeImagePlus/FreeImagePlus.rc.in
+++ b/Wrapper/FreeImagePlus/FreeImagePlus.rc.in
@@ -6,8 +6,8 @@
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,19,12,0
- PRODUCTVERSION 3,19,12,0
+ FILEVERSION @FREEIMAGE_VERSION_MAJOR@,@FREEIMAGE_VERSION_MINOR@,@FREEIMAGE_VERSION_PATCH@,@FREEIMAGE_VERSION_COMMITS@
+ PRODUCTVERSION @FREEIMAGE_VERSION_MAJOR@,@FREEIMAGE_VERSION_MINOR@,@FREEIMAGE_VERSION_PATCH@,@FREEIMAGE_VERSION_COMMITS@
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -25,14 +25,14 @@ BEGIN
             VALUE "Comments", "FreeImage is an Open Source library project for developers who would like to support popular graphics image formats like PNG, BMP, JPEG, TIFF and others as needed by today's multimedia applications.\0"
             VALUE "CompanyName", "FreeImage\0"
             VALUE "FileDescription", "FreeImagePlus library\0"
-            VALUE "FileVersion", "3, 19, 12, 0\0"
+            VALUE "FileVersion", "@FREEIMAGE_VERSION_STRING@\0"
             VALUE "InternalName", "FreeImagePlus\0"
-            VALUE "LegalCopyright", "Copyright © 2003-2026 by FreeImage\0"
+            VALUE "LegalCopyright", "Copyright © 2003-@FREEIMAGE_COPYRIGHT_YEAR@ by FreeImage\0"
             VALUE "LegalTrademarks", "See https://freeimage.sourceforge.net\0"
             VALUE "OriginalFilename", "FreeImagePlus.dll\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "FreeImagePlus\0"
-            VALUE "ProductVersion", "3, 19, 12, 0\0"
+            VALUE "ProductVersion", "@FREEIMAGE_VERSION_STRING@\0"
             VALUE "SpecialBuild", "\0"
         END
     END


### PR DESCRIPTION
`FreeImage.rc`/`FreeImagePlus.rc` had hand-maintained, stale version numbers (`3,19,0,0` and `3,18,0,0` — both behind the actual `3.19.12` tag) and copyright years (2003-2020, 2003-2018). `FreeImage_GetVersion()` itself was also stuck reporting "3.19.0".

## Changes
- `CMakeLists.txt` now runs `git describe --tags --long` before `project()` to determine the real version, falling back to a static default when building from a source archive without `.git` history.
- New `FreeImage.rc.in` → `configure_file()`-generated into the build dir and added to the Windows build's sources, so CMake-built DLLs get automatically correct, never-stale `FILEVERSION`/`PRODUCTVERSION`/copyright year going forward — no more manual bumping.
- `Wrapper/FreeImagePlus` has no CMake target yet, so `FreeImagePlus.rc.in` is added as a template for later, and the checked-in `FreeImagePlus.rc` gets the same one-time fix (it's used directly by the legacy, non-CMake VS2017 project).
- Bumped `FREEIMAGE_RELEASE_SERIAL` in `FreeImage.h` from `0` to `12`. This stays static/manually-maintained per release (unlike the `.rc` files) since it's the public C API contract, expected to work even when this header is vendored elsewhere without our build tooling.

## Test plan
- [x] `FreeImage_GetVersion()` now returns `"3.19.12"`.
- [x] A real CMake configure run produces `FILEVERSION 3,19,12,44` with the current copyright year and an `https` link, matching the actual git state (44 commits past the `3.19.12` tag at time of testing).
- [x] Full build + `ctest` suite passes.
- [x] Non-Windows builds unaffected — the generated `.rc` is only added to sources when `WIN32`.