### PR TITLE
Enable BUILD_OPENEXR by default on C++17+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.16)
 project(FreeImage VERSION 3.19.0 LANGUAGES C CXX)
 
+# Set C and C++ standards if provided. Applied early (before any option()
+# calls below) so BUILD_OPENEXR's default, further down, can see whichever
+# standard was actually requested.
+if (DEFINED C_STANDARD)
+    set(CMAKE_C_STANDARD ${C_STANDARD})
+endif()
+if (DEFINED CPP_STANDARD)
+    set(CMAKE_CXX_STANDARD ${CPP_STANDARD})
+endif()
+
 # Options for configuring the build
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
@@ -27,7 +37,13 @@ option(BUILD_LIBJPEG "Build libjpeg from source or link" ON)
 option(BUILD_LIBOPENJPEG "Build OpenJPEG from source or link" ON)
 option(BUILD_WEBP "Build webp from source or link" ON)
 option(BUILD_LIBRAWLITE "Build librawlite from source or link" OFF)
-option(BUILD_OPENEXR "Build OpenEXR from source or link" OFF)
+# Default ON, but only when C++17+ is actually in effect (OpenEXR needs it).
+if(NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+    set(BUILD_OPENEXR_DEFAULT ON)
+else()
+    set(BUILD_OPENEXR_DEFAULT OFF)
+endif()
+option(BUILD_OPENEXR "Build OpenEXR from source or link" ${BUILD_OPENEXR_DEFAULT})
 
 # When ON, sets the default for every USE_SYSTEM_* option below to ON (each
 # can still be overridden individually). Mirrors what MSYS2's
@@ -70,14 +86,6 @@ if(FREEIMAGE_STATIC)
     add_definitions(-DFREEIMAGE_LIB)
 else()
     message(STATUS "Building FreeImage as a shared library.")
-endif()
-
-# Set C and C++ standards if provided
-if (DEFINED C_STANDARD)
-    set(CMAKE_C_STANDARD ${C_STANDARD})
-endif()
-if (DEFINED CPP_STANDARD)
-    set(CMAKE_CXX_STANDARD ${CPP_STANDARD})
 endif()
 
 #set(NO_BUILD_OPTIONS LIBRAWLITE LIBTIFF)
@@ -972,14 +980,6 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC
     NO_LCMS
     NO_WINDOWS
 )
-
-# Set C++ standard
-if (DEFINED C_STANDARD)
-    set(CMAKE_C_STANDARD ${C_STANDARD})
-endif()
-if (DEFINED CPP_STANDARD)
-    set(CMAKE_CXX_STANDARD ${CPP_STANDARD})
-endif()
 
 
 # Apple-specific settings


### PR DESCRIPTION
`BUILD_OPENEXR` defaulted OFF unconditionally. Now defaults ON whenever C++17+ is actually in effect, OFF when an older standard was explicitly requested — so this project's own C++11/14 CI matrix entries keep building without OpenEXR rather than hitting the existing hard error for `BUILD_OPENEXR` + <C++17.

Also removed two more copies of the C_STANDARD/CPP_STANDARD handling block that were duplicated verbatim elsewhere in the file (found while relocating it earlier in the file so the new default can see the requested standard) — same class of copy-paste redundancy as the `BUILD_SHARED_LIBS` message duplication fixed in #82.

## Test plan
- [x] no flags → `BUILD_OPENEXR=ON` (new default)
- [x] `-DCMAKE_CXX_STANDARD=11` → `BUILD_OPENEXR=OFF`, no error
- [x] `-DCMAKE_CXX_STANDARD=17` → `BUILD_OPENEXR=ON`
- [x] `-DCPP_STANDARD=11` → `BUILD_OPENEXR=OFF`
- [x] `-DBUILD_OPENEXR=ON -DCMAKE_CXX_STANDARD=11` → still hard errors (explicit conflict)
- [x] Full build (new default) + `ctest` suite passes