### PR TITLE
Add windows-clang-cl CI job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -100,6 +100,25 @@ jobs:
         run: |
           ctest --test-dir build --build-config Debug --verbose
 
+  windows-clang-cl:
+    # Issue #29: build with Clang on Windows via clang-cl, the MSVC-ABI-compatible
+    # driver windows-latest ships preinstalled as a VS toolset. Same generator as
+    # the windows-msvc entry above, just switching the toolset with -T ClangCL.
+    name: windows-clang-cl
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Configure
+        run: |
+          cmake -S . -B build -T ClangCL -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=17 -DUNICODE=ON -D_UNICODE=ON
+      - name: Build
+        run: |
+          cmake --build build --config Debug
+      - name: Test
+        run: |
+          ctest --test-dir build --build-config Debug --verbose
+
   openframeworks-tests:
     # Builds this FreeImage checkout and drops it into a real openFrameworks
     # checkout in place of oF's own prebuilt copy, then runs oF's

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -119,6 +119,31 @@ jobs:
         run: |
           ctest --test-dir build --build-config Debug --verbose
 
+  windows-clang-cl-ninja:
+    # Issue #29 also asks for clang-cl driven directly via Ninja (not just
+    # the VS-generator toolset switch above), which needs the MSVC dev
+    # environment (INCLUDE/LIB/PATH) set up explicitly since Ninja has no
+    # equivalent of the VS generator's own toolset detection.
+    name: windows-clang-cl (Ninja)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up MSVC developer environment
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=17 -DUNICODE=ON -D_UNICODE=ON -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      - name: Build
+        run: |
+          cmake --build build
+      - name: Test
+        run: |
+          ctest --test-dir build --build-config Debug --verbose
+
   openframeworks-tests:
     # Builds this FreeImage checkout and drops it into a real openFrameworks
     # checkout in place of oF's own prebuilt copy, then runs oF's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,20 @@ if(BUILD_WEBP)
     # as <webp/decode.h>, which needs Source/LibWebP/src on the path too.
     include_directories(Source/LibWebP/src)
     add_definitions(-DINCLUDE_LIB_WEBP)
+
+    # Real MSVC doesn't gate SIMD intrinsics on /arch:, but clang-cl (which
+    # also defines _MSC_VER) does enforce per-function target features - so
+    # LibWebP's hand-dispatched SSE4.1/AVX2 sources need the matching -m
+    # flags explicitly under clang-cl, passed through via its /clang: prefix.
+    if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        foreach(_webp_simd_src ${FreeImage_WEBP_SRCS})
+            if(_webp_simd_src MATCHES "_sse41\\.c$")
+                set_source_files_properties(${_webp_simd_src} PROPERTIES COMPILE_OPTIONS "/clang:-msse4.1")
+            elseif(_webp_simd_src MATCHES "_avx2\\.c$")
+                set_source_files_properties(${_webp_simd_src} PROPERTIES COMPILE_OPTIONS "/clang:-mavx2")
+            endif()
+        endforeach()
+    endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1009,6 +1009,16 @@ if(BUILD_OPENEXR)
         include_directories(Source/Imath)
         include_directories(Source/LibDeflate)
         add_definitions(-DINCLUDE_LIB_OPENEXR)
+
+        # Same clang-cl vs real-MSVC target-feature gating issue as LibWebP
+        # above: OpenEXR's own runtime-dispatched SSE2/SSSE3/SSE4.1/AVX2
+        # paths (ImfZip.cpp, internal_zip.c, internal_dwa.c, unpack.c, ...)
+        # compile unconditionally, real MSVC doesn't need /arch: for them,
+        # clang-cl does.
+        if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            set_source_files_properties(${FreeImage_OPENEXR_SRCS} ${FreeImage_OPENEXRCORE_SRCS}
+                PROPERTIES COMPILE_OPTIONS "/clang:-mssse3;/clang:-msse4.1;/clang:-mavx;/clang:-mavx2")
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -990,8 +990,8 @@ if (APPLE)
     endif()
 endif()
 
-# Enable Multi-core compilation in MSVC
-if (MSVC)
+# Enable Multi-core compilation in MSVC (not supported by clang-cl)
+if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE /MP)
 endif()
 if (WIN32)


### PR DESCRIPTION
Addresses #29.

Adds a CI job that builds with clang-cl (the MSVC-ABI-compatible Clang driver windows-latest ships preinstalled as a VS toolset), reusing the same VS generator the existing windows-msvc entry uses, just switching toolset via `-T ClangCL`.

Also guards the `/MP` compile flag in CMakeLists.txt to MSVC-proper (`CMAKE_CXX_COMPILER_ID` is `Clang` under clang-cl even though `MSVC` stays true) since clang-cl doesn't support it.