### PR TITLE
Disable BUILD_OPENEXR for the windows-mingw CI job (hangs pre-main)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,15 @@ jobs:
           if [ "${{ matrix.compiler }}" == "msvc" ]; then
             cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.cppstandard }} -DUNICODE=ON -D_UNICODE=ON -DCMAKE_C_STANDARD=${{ matrix.cstandard }}
           elif [ "${{ matrix.compiler }}" == "mingw" ]; then
-            cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DUNICODE=ON -D_UNICODE=ON -DCMAKE_CXX_STANDARD=${{ matrix.cppstandard }} -DCMAKE_C_STANDARD=${{ matrix.cstandard }} -G "MinGW Makefiles"
+            # BUILD_OPENEXR=ON (the default for C++17+ since #85) hangs the
+            # test binary before main() even runs on this job's preinstalled
+            # mingw toolchain - reproduces on master, narrowed down to some
+            # static/module-load-time initializer in the OpenEXR dependency
+            # chain, not yet root-caused. windows-mingw-w64 below (a current
+            # MSYS2 GCC toolchain, not whatever ships on windows-latest)
+            # doesn't hit this, so it's specific to this toolchain rather
+            # than mingw/GCC in general. Force it off here until root-caused.
+            cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DUNICODE=ON -D_UNICODE=ON -DCMAKE_CXX_STANDARD=${{ matrix.cppstandard }} -DCMAKE_C_STANDARD=${{ matrix.cstandard }} -DBUILD_OPENEXR=OFF -G "MinGW Makefiles"
           else
             cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DUNICODE=ON -D_UNICODE=ON -DCMAKE_CXX_STANDARD=${{ matrix.cppstandard }} -DCMAKE_C_STANDARD=${{ matrix.cstandard }}
           fi


### PR DESCRIPTION
Master's own CI is currently red: \`windows-mingw (C++17)\`, \`(C++20)\`, and \`(C++23)\` all hang for the full 25-minute ctest timeout, reproduced on master's latest run independent of any other open PR. \`windows-mingw (C++11)\` passes. The dividing line is exactly the C++17 threshold, i.e. exactly when #85 turns \`BUILD_OPENEXR\` on by default - the only C++17-conditional logic in \`CMakeLists.txt\`.

## What I ruled out

- Tried disabling OpenEXR's IlmThread pool (\`ILMTHREAD_THREADING_ENABLED=0\`), suspecting a known upstream shutdown deadlock (AcademySoftwareFoundation/openexr#890). Verified via CI: still hangs identically.
- Added diagnostic instrumentation to \`TestAPI/MainTestSuite.cpp\` writing progress to a file (ctest doesn't surface a timed-out test's stdout, so a plain printf trace showed nothing). The file was never created at all - the hang happens **before \`main()\` even starts**, i.e. in a global/static constructor or module-load-time initializer somewhere in the OpenEXR/Imath/IlmThread/OpenEXRCore/LibDeflate chain now linked in. Pinning down which one needs a debugger attached to a live hung Windows process, which isn't available in this environment.
- \`windows-mingw-w64\` (a current MSYS2 GCC toolchain) does *not* hit this - only the \`windows-mingw\` job's preinstalled windows-latest toolchain does, so it's toolchain-specific rather than a general mingw/GCC issue.

## Fix (mitigation, not root cause)

Pass \`-DBUILD_OPENEXR=OFF\` explicitly for the \`windows-mingw\` job's C++17/20/23 configs. \`BUILD_OPENEXR\`'s default (on for C++17+, from #85) is unchanged for real builds - this only stops CI from exercising a combination that's currently broken on this specific toolchain. Root-causing the actual static-init issue needs someone with real Windows/mingw debugging access.