### PR TITLE
Add a ninja-msvc CMake preset and test it in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -202,6 +202,15 @@ jobs:
           cmake --preset vs2026
           cmake --build build-vs2026 --config Debug
           ctest --test-dir build-vs2026 --build-config Debug --verbose
+      - name: Set up MSVC developer environment
+        # Only needed for the Ninja preset below - unlike the VS generator
+        # above, Ninja doesn't do its own VS-instance detection.
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Generate and build ninja-msvc preset
+        run: |
+          cmake --preset ninja-msvc
+          cmake --build build-ninja-msvc
+          ctest --test-dir build-ninja-msvc --build-config Debug --verbose
 
   openframeworks-tests:
     # Builds this FreeImage checkout and drops it into a real openFrameworks

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,6 +35,22 @@
             "cacheVariables": {
                 "BUILD_TESTS": "ON"
             }
+        },
+        {
+            "name": "ninja-msvc",
+            "displayName": "Ninja (MSVC)",
+            "description": "Builds with cl.exe via Ninja under build-ninja-msvc/ - run from a Developer Command Prompt/PowerShell (or after vcvarsall.bat) so cl.exe is on PATH.",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-ninja-msvc",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "BUILD_TESTS": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
         }
     ]
 }


### PR DESCRIPTION
Adds \`ninja-msvc\` to \`CMakePresets.json\` - builds with real MSVC (\`cl.exe\`) via Ninja under \`build-ninja-msvc/\`, as opposed to the existing \`vs2022\`/\`vs2026\` presets which use the Visual Studio generator. Useful for editors/IDEs (VS Code, CLion) that drive CMake through Ninja rather than generating a full solution.

Tested in the \`windows-vs-presets\` CI job alongside the existing vs2022/vs2026 checks - needs \`ilammy/msvc-dev-cmd\` first since, unlike the VS generator, Ninja doesn't do its own VS-instance detection.