### PR TITLE
Fix ARM64EC Windows build: don't include raw x86 intrinsic headers there

### DIFF
--- a/Source/LibTIFF4/tif_predict.c
+++ b/Source/LibTIFF4/tif_predict.c
@@ -30,7 +30,10 @@
 #include "tif_predict.h"
 #include "tiffiop.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
+/* _M_X64 is also defined for ARM64EC, where MSVC's emmintrin.h requires
+ * going through intrin.h - not worth chasing, just fall back to the
+ * portable path there. */
+#if defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))
 #include <emmintrin.h>
 #endif
 
@@ -590,7 +593,10 @@ static int fpAcc(TIFF *tif, uint8_t *cp0, tmsize_t cc)
     cp = (uint8_t *)cp0;
     count = 0;
 
-#if defined(__x86_64__) || defined(_M_X64)
+/* _M_X64 is also defined for ARM64EC, where MSVC's emmintrin.h requires
+ * going through intrin.h - not worth chasing, just fall back to the
+ * portable path there. */
+#if defined(__x86_64__) || (defined(_M_X64) && !defined(_M_ARM64EC))
     if (bps == 4)
     {
         /* Optimization of general case */

--- a/Source/LibWebP/src/dsp/cpu.c
+++ b/Source/LibWebP/src/dsp/cpu.c
@@ -72,8 +72,11 @@ static WEBP_INLINE uint64_t xgetbv(void) {
     : "=a"(eax), "=d"(edx) : "c" (ecx));
   return ((uint64_t)edx << 32) | eax;
 }
-#elif (defined(_M_X64) || defined(_M_IX86)) && \
+#elif (defined(_M_X64) || defined(_M_IX86)) && !defined(_M_ARM64EC) && \
       defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 160040219  // >= VS2010 SP1
+// _M_X64 is also defined for ARM64EC, where MSVC's immintrin.h requires
+// going through intrin.h - excluded above, falls through to the portable
+// __asm path below instead.
 #include <immintrin.h>
 #define xgetbv() _xgetbv(0)
 #elif defined(_MSC_VER) && defined(_M_IX86)


### PR DESCRIPTION
Surfaced by openFrameworks' apothecary build for Windows ARM64EC: https://github.com/openframeworks/apothecary/actions/runs/32367459035/job/96420065340?pr=587

\`\`\`
emmintrin.h(24,1): error C1189: #error: this header should only be included through <intrin.h>
  (compiling source file '../Source/LibTIFF4/tif_predict.c')
\`\`\`

MSVC defines \`_M_X64\` for ARM64EC builds too (it's x64-ABI-compatible), but its \`emmintrin.h\`/\`immintrin.h\` headers refuse to be included directly there - only via \`<intrin.h>\`. Two spots in this tree gate raw x86 intrinsic headers on \`_M_X64\` alone:

- \`Source/LibTIFF4/tif_predict.c\` (2 sites) - SSE2 predictor optimization
- \`Source/LibWebP/src/dsp/cpu.c\` - \`_xgetbv\` for AVX detection

Both already have a safe, portable fallback path for when the SIMD path isn't available, so the fix is just to exclude \`_M_ARM64EC\` from the guard rather than try to make the intrinsics work correctly through ARM64EC's x64 emulation layer.