### PR TITLE
Fix 6 unpatched CVEs from issue #35: OOB reads in IPTC/Exif, XPM, RAS

### DIFF
--- a/Source/FreeImage/PluginRAS.cpp
+++ b/Source/FreeImage/PluginRAS.cpp
@@ -203,7 +203,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 
 	FIBITMAP *dib = NULL;
 	BYTE *bits;			// Pointer to dib data
-	WORD x, y;
+	// DWORD, not WORD: header.width/height are DWORD, and x/y are compared
+	// against them below - a WORD x or y would wrap at 65536 for a crafted
+	// large image, turning "for (x = 0; x < header.width; x++)" into an
+	// effectively unbounded loop that walks bits/buf far past their real size.
+	DWORD x, y;
 
 	if(!handle) {
 		return NULL;
@@ -398,7 +402,17 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			{
 				BYTE *buf, *bp;
 
+				// header.width * 3 is DWORD arithmetic and can wrap for a
+				// crafted huge width - the per-pixel copy loop below still
+				// iterates the real (unwrapped) header.width times, so a
+				// wrapped, undersized buf would be read/written past its end.
+				if (header.width > ((DWORD)-1) / 3) {
+					throw "RAS: invalid width";
+				}
 				buf = (BYTE*)malloc(header.width * 3);
+				if (!buf) {
+					throw FI_MSG_ERROR_MEMORY;
+				}
 
 				for (y = 0; y < header.height; y++) {
 					bits = FreeImage_GetBits(dib) + (header.height - 1 - y) * pitch;
@@ -438,7 +452,14 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			{
 				BYTE *buf, *bp;
 
+				// see the case 24 comment above - same overflow risk, *4 instead of *3.
+				if (header.width > ((DWORD)-1) / 4) {
+					throw "RAS: invalid width";
+				}
 				buf = (BYTE*)malloc(header.width * 4);
+				if (!buf) {
+					throw FI_MSG_ERROR_MEMORY;
+				}
 
 				for (y = 0; y < header.height; y++) {
 					bits = FreeImage_GetBits(dib) + (header.height - 1 - y) * pitch;

--- a/Source/FreeImage/PluginRAS.cpp
+++ b/Source/FreeImage/PluginRAS.cpp
@@ -195,7 +195,7 @@ SupportsNoPixels() {
 static FIBITMAP * DLL_CALLCONV
 Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 	SUNHEADER header;	// Sun file header
-	WORD linelength;	// Length of raster line in bytes
+	DWORD linelength;	// Length of raster line in bytes
 	WORD fill;			// Number of fill bytes per raster line
 	BOOL rle;			// TRUE if RLE file
 	BOOL isRGB;			// TRUE if file type is RT_FORMAT_RGB
@@ -203,7 +203,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 
 	FIBITMAP *dib = NULL;
 	BYTE *bits;			// Pointer to dib data
-	WORD x, y;
+	DWORD x, y;
 
 	if(!handle) {
 		return NULL;
@@ -364,9 +364,9 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		// Each row is multiple of 16 bits (2 bytes).
 
 		if (header.depth == 1) {
-			linelength = (WORD)((header.width / 8) + (header.width % 8 ? 1 : 0));
+			linelength = (header.width / 8) + (header.width % 8 ? 1 : 0);
 		} else {
-			linelength = (WORD)header.width;
+			linelength = header.width;
 		}
 
 		fill = (linelength % 2) ? 1 : 0;
@@ -398,7 +398,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			{
 				BYTE *buf, *bp;
 
+				if (header.width > ((DWORD)-1) / 3) {
+					throw "RAS: invalid width";
+				}
 				buf = (BYTE*)malloc(header.width * 3);
+				if (!buf) {
+					throw FI_MSG_ERROR_MEMORY;
+				}
 
 				for (y = 0; y < header.height; y++) {
 					bits = FreeImage_GetBits(dib) + (header.height - 1 - y) * pitch;
@@ -438,7 +444,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			{
 				BYTE *buf, *bp;
 
+				if (header.width > ((DWORD)-1) / 4) {
+					throw "RAS: invalid width";
+				}
 				buf = (BYTE*)malloc(header.width * 4);
+				if (!buf) {
+					throw FI_MSG_ERROR_MEMORY;
+				}
 
 				for (y = 0; y < header.height; y++) {
 					bits = FreeImage_GetBits(dib) + (header.height - 1 - y) * pitch;

--- a/Source/FreeImage/PluginXPM.cpp
+++ b/Source/FreeImage/PluginXPM.cpp
@@ -313,7 +313,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		for(int y = 0; y < height; y++ ) {
 			BYTE *line = FreeImage_GetScanLine(dib, height - y - 1);
 			str = ReadString(io, handle);
-			if(!str)
+			// a row string shorter than width*cpp would let pixel_ptr walk
+			// past the end of str's allocation in the loop below - the
+			// color table parsing above already guards against this same
+			// class of short-string issue, this loop didn't.
+			if(!str || (strlen(str) < (size_t)width * (size_t)cpp))
 				throw "Error reading pixel strings";
 			char *pixel_ptr = str;
 

--- a/Source/FreeImage/PluginXPM.cpp
+++ b/Source/FreeImage/PluginXPM.cpp
@@ -313,7 +313,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		for(int y = 0; y < height; y++ ) {
 			BYTE *line = FreeImage_GetScanLine(dib, height - y - 1);
 			str = ReadString(io, handle);
-			if(!str)
+			if(!str || (strlen(str) < (size_t)width * (size_t)cpp))
 				throw "Error reading pixel strings";
 			char *pixel_ptr = str;
 

--- a/Source/Metadata/Exif.cpp
+++ b/Source/Metadata/Exif.cpp
@@ -201,12 +201,17 @@ It can also contain
 @param subdirOffset [output] Offset into the IFD
 @param md_model [output] Metadata model to process
 */
-static void 
-processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirOffset, TagLib::MDMODEL *md_model) {
+static void
+processMakerNote(FIBITMAP *dib, const char *pval, DWORD length, BOOL msb_order, DWORD *subdirOffset, TagLib::MDMODEL *md_model) {
 	FITAG *tagMake = NULL;
 
 	*subdirOffset = 0;
 	*md_model = TagLib::UNKNOWN;
+
+	// The MakerNote tag's declared length only guarantees `length` bytes are
+	// readable at pval - every fixed-size signature check below must stay
+	// within that, since camera-supplied MakerNote data is untrusted input.
+#define MN_MATCH(lit, len) (length >= (DWORD)(len) && memcmp(lit, pval, len) == 0)
 
 	// Determine the camera model and makernote format
 	// WARNING: note that Maker may be NULL sometimes so check its value before using it
@@ -214,20 +219,20 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Make", &tagMake);
 	const char *Maker = (char*)FreeImage_GetTagValue(tagMake);
 
-	if((memcmp("OLYMP\x00\x01", pval, 7) == 0) || (memcmp("OLYMP\x00\x02", pval, 7) == 0) || (memcmp("EPSON", pval, 5) == 0) || (memcmp("AGFA", pval, 4) == 0)) {
+	if(MN_MATCH("OLYMP\x00\x01", 7) || MN_MATCH("OLYMP\x00\x02", 7) || MN_MATCH("EPSON", 5) || MN_MATCH("AGFA", 4)) {
 		// Olympus Type 1 Makernote
-		// Epson and Agfa use Olympus maker note standard, 
+		// Epson and Agfa use Olympus maker note standard,
 		// see: http://www.ozhiker.com/electronics/pjmt/jpeg_info/
 		*md_model = TagLib::EXIF_MAKERNOTE_OLYMPUSTYPE1;
 		*subdirOffset = 8;
-	} 
-	else if(memcmp("OLYMPUS\x00\x49\x49\x03\x00", pval, 12) == 0) {
+	}
+	else if(MN_MATCH("OLYMPUS\x00\x49\x49\x03\x00", 12)) {
 		// Olympus Type 2 Makernote
 		// !!! NOT YET SUPPORTED !!!
 		*md_model = TagLib::UNKNOWN;
 		*subdirOffset = 0;
 	}
-	else if(memcmp("Nikon", pval, 5) == 0) {
+	else if(MN_MATCH("Nikon", 5)) {
 		/* There are two scenarios here:
 		 * Type 1:
 		 * :0000: 4E 69 6B 6F 6E 00 01 00-05 00 02 00 02 00 06 00 Nikon...........
@@ -236,11 +241,11 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		 * :0000: 4E 69 6B 6F 6E 00 02 00-00 00 4D 4D 00 2A 00 00 Nikon....MM.*...
 		 * :0010: 00 08 00 1E 00 01 00 07-00 00 00 04 30 32 30 30 ............0200
 		 */
-		if (pval[6] == 1) {
+		if (length >= 7 && pval[6] == 1) {
 			// Nikon type 1 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_NIKONTYPE1;
 			*subdirOffset = 8;
-        } else if (pval[6] == 2) {
+        } else if (length >= 7 && pval[6] == 2) {
             // Nikon type 3 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_NIKONTYPE3;
 			*subdirOffset = 18;
@@ -259,7 +264,7 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		*subdirOffset = 0;
 	} else if(Maker && (FreeImage_strnicmp("Casio", Maker, 5) == 0)) {
         // Casio Makernote
-		if(memcmp("QVC\x00\x00\x00", pval, 6) == 0) {
+		if(MN_MATCH("QVC\x00\x00\x00", 6)) {
 			// Casio Type 2 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_CASIOTYPE2;
 			*subdirOffset = 6;
@@ -268,17 +273,19 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 			*md_model = TagLib::EXIF_MAKERNOTE_CASIOTYPE1;
 			*subdirOffset = 0;
 		}
-	} else if ((memcmp("FUJIFILM", pval, 8) == 0) || (Maker && (FreeImage_strnicmp("Fujifilm", Maker, 8) == 0))) {
+	} else if (MN_MATCH("FUJIFILM", 8) || (Maker && (FreeImage_strnicmp("Fujifilm", Maker, 8) == 0))) {
         // Fujifile Makernote
-		// Fujifilm's Makernote always use little-endian order altough the Exif section maybe in little-endian order or in big-endian order. 
-		// If msb_order == TRUE, the Makernote won't be read: 
-		// the value of ifdStart will be 0x0c000000 instead of 0x0000000c and the MakerNote section will be 
+		// Fujifilm's Makernote always use little-endian order altough the Exif section maybe in little-endian order or in big-endian order.
+		// If msb_order == TRUE, the Makernote won't be read:
+		// the value of ifdStart will be 0x0c000000 instead of 0x0000000c and the MakerNote section will be
 		// discarded later in jpeg_read_exif_dir because the IFD is too high
 		*md_model = TagLib::EXIF_MAKERNOTE_FUJIFILM;
-        DWORD ifdStart = ReadUint32(msb_order, pval + 8);
-		*subdirOffset = ifdStart;
+		if (length >= 12) {
+			DWORD ifdStart = ReadUint32(msb_order, pval + 8);
+			*subdirOffset = ifdStart;
+		}
     }
-	else if(memcmp("KYOCERA\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x00\x00\x00", pval, 22) == 0) {
+	else if(MN_MATCH("KYOCERA\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x00\x00\x00", 22)) {
 		*md_model = TagLib::EXIF_MAKERNOTE_KYOCERA;
 		*subdirOffset = 22;
 	}
@@ -287,14 +294,14 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		*md_model = TagLib::EXIF_MAKERNOTE_MINOLTA;
 		*subdirOffset = 0;
 	}
-	else if(memcmp("Panasonic\x00\x00\x00", pval, 12) == 0) {
+	else if(MN_MATCH("Panasonic\x00\x00\x00", 12)) {
 		// Panasonic maker note
 		*md_model = TagLib::EXIF_MAKERNOTE_PANASONIC;
 		*subdirOffset = 12;
 	}
 	else if(Maker && (FreeImage_strnicmp("LEICA", Maker, 5) == 0)) {
 		// Leica maker note
-		if(memcmp("LEICA\x00\x00\x00", pval, 8) == 0) {
+		if(MN_MATCH("LEICA\x00\x00\x00", 8)) {
 			// not yet supported makernote data ignored
 			*md_model = TagLib::UNKNOWN;
 			*subdirOffset = 0;
@@ -302,7 +309,7 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	}
 	else if(Maker && ((FreeImage_strnicmp("Pentax", Maker, 6) == 0) || (FreeImage_strnicmp("Asahi", Maker, 5) == 0))) {
 		// Pentax maker note
-		if(memcmp("AOC\x00", pval, 4) == 0) {
+		if(MN_MATCH("AOC\x00", 4)) {
 			// Type 2 Pentax Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_PENTAX;
 			*subdirOffset = 6;
@@ -311,12 +318,12 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 			*md_model = TagLib::EXIF_MAKERNOTE_ASAHI;
 			*subdirOffset = 0;
 		}
-	}	
-	else if((memcmp("SONY CAM\x20\x00\x00\x00", pval, 12) == 0) || (memcmp("SONY DSC\x20\x00\x00\x00", pval, 12) == 0)) {
+	}
+	else if(MN_MATCH("SONY CAM\x20\x00\x00\x00", 12) || MN_MATCH("SONY DSC\x20\x00\x00\x00", 12)) {
 		*md_model = TagLib::EXIF_MAKERNOTE_SONY;
 		*subdirOffset = 12;
 	}
-	else if((memcmp("SIGMA\x00\x00\x00", pval, 8) == 0) || (memcmp("FOVEON\x00\x00", pval, 8) == 0)) {
+	else if(MN_MATCH("SIGMA\x00\x00\x00", 8) || MN_MATCH("FOVEON\x00\x00", 8)) {
 		FITAG *tagModel = NULL;
 		FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Model", &tagModel);
 		const char *Model = (char*)FreeImage_GetTagValue(tagModel);
@@ -332,16 +339,18 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	}
 	else if (Maker && (FreeImage_strnicmp("Apple", Maker, 5) == 0)) {
 		// Apple maker note
-		if (memcmp("Apple iOS", pval, 9) == 0) {
+		if (MN_MATCH("Apple iOS", 9)) {
 			// Apple iOS Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_APPLE_IOS;
 			*subdirOffset = 14;
 		}
 	}
+
+#undef MN_MATCH
 }
 
 /**
-Process a Canon maker note tag. 
+Process a Canon maker note tag.
 A single Canon tag may contain many other tags within.
 
 @param dib Image to be processed
@@ -718,7 +727,7 @@ jpeg_read_exif_dir(FIBITMAP *dib, const BYTE *tiffp, DWORD dwOffsetIfd0, DWORD d
 				
 				// get offset and metadata model
 				if (FreeImage_GetTagID(tag) == TAG_MAKER_NOTE) {
-					processMakerNote(dib, pval, msb_order, &sub_offset, &next_mdmodel);
+					processMakerNote(dib, pval, FreeImage_GetTagLength(tag), msb_order, &sub_offset, &next_mdmodel);
 					next_ifd = (BYTE*)pval + sub_offset;
 				} else {
 					processIFDOffset(tag, pval, msb_order, &sub_offset, &next_mdmodel);
@@ -879,7 +888,14 @@ jpeg_read_exif_profile(FIBITMAP *dib, const BYTE *data, unsigned length) {
 	DWORD dwProfileLength = (DWORD)length;
 	BYTE *pbProfile = (BYTE*)data;
 
-	// verify the identifying string
+	// verify the identifying string - length is attacker-controlled (comes
+	// straight from the JPEG APP1 marker's declared size), so it must cover
+	// at least the signature before memcmp reads it, and at least the 8-byte
+	// TIFF header that follows before that gets read below
+	if(dwProfileLength < sizeof(exif_signature) + 8) {
+		return FALSE;
+	}
+
 	if(memcmp(exif_signature, pbProfile, sizeof(exif_signature)) == 0) {
 		// This is an Exif profile
 		// should contain a TIFF header with up to 2 IFDs (IFD stands for 'Image File Directory')
@@ -891,7 +907,7 @@ jpeg_read_exif_profile(FIBITMAP *dib, const BYTE *data, unsigned length) {
 		// read the TIFF header (8 bytes)
 
 		// check the endianess order
-		
+
 		BOOL bBigEndian = TRUE;
 
 		if(memcmp(pbProfile, lsb_first, sizeof(lsb_first)) == 0) {
@@ -948,8 +964,10 @@ jpeg_read_exif_profile_raw(FIBITMAP *dib, const BYTE *profile, unsigned length) 
     // marker identifying string for Exif = "Exif\0\0"
     BYTE exif_signature[6] = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
 
-	// verify the identifying string
-	if(memcmp(exif_signature, profile, sizeof(exif_signature)) != 0) {
+	// verify the identifying string - length is attacker-controlled (comes
+	// straight from the JPEG APP1 marker's declared size), so it must cover
+	// the signature before memcmp reads it
+	if(length < sizeof(exif_signature) || memcmp(exif_signature, profile, sizeof(exif_signature)) != 0) {
 		// not an Exif profile
 		return FALSE;
 	}

--- a/Source/Metadata/Exif.cpp
+++ b/Source/Metadata/Exif.cpp
@@ -197,16 +197,19 @@ It can also contain
 
 @param dib Image to be processed
 @param pval Current Exif IFD memory pointer
+@param length Number of readable bytes at pval
 @param msb_order Endianness order of the Exif file (TRUE if big-endian, FALSE if little-endian)
 @param subdirOffset [output] Offset into the IFD
 @param md_model [output] Metadata model to process
 */
-static void 
-processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirOffset, TagLib::MDMODEL *md_model) {
+static void
+processMakerNote(FIBITMAP *dib, const char *pval, DWORD length, BOOL msb_order, DWORD *subdirOffset, TagLib::MDMODEL *md_model) {
 	FITAG *tagMake = NULL;
 
 	*subdirOffset = 0;
 	*md_model = TagLib::UNKNOWN;
+
+#define MN_MATCH(lit, len) (length >= (DWORD)(len) && memcmp(lit, pval, len) == 0)
 
 	// Determine the camera model and makernote format
 	// WARNING: note that Maker may be NULL sometimes so check its value before using it
@@ -214,20 +217,20 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Make", &tagMake);
 	const char *Maker = (char*)FreeImage_GetTagValue(tagMake);
 
-	if((memcmp("OLYMP\x00\x01", pval, 7) == 0) || (memcmp("OLYMP\x00\x02", pval, 7) == 0) || (memcmp("EPSON", pval, 5) == 0) || (memcmp("AGFA", pval, 4) == 0)) {
+	if(MN_MATCH("OLYMP\x00\x01", 7) || MN_MATCH("OLYMP\x00\x02", 7) || MN_MATCH("EPSON", 5) || MN_MATCH("AGFA", 4)) {
 		// Olympus Type 1 Makernote
-		// Epson and Agfa use Olympus maker note standard, 
+		// Epson and Agfa use Olympus maker note standard,
 		// see: http://www.ozhiker.com/electronics/pjmt/jpeg_info/
 		*md_model = TagLib::EXIF_MAKERNOTE_OLYMPUSTYPE1;
 		*subdirOffset = 8;
-	} 
-	else if(memcmp("OLYMPUS\x00\x49\x49\x03\x00", pval, 12) == 0) {
+	}
+	else if(MN_MATCH("OLYMPUS\x00\x49\x49\x03\x00", 12)) {
 		// Olympus Type 2 Makernote
 		// !!! NOT YET SUPPORTED !!!
 		*md_model = TagLib::UNKNOWN;
 		*subdirOffset = 0;
 	}
-	else if(memcmp("Nikon", pval, 5) == 0) {
+	else if(MN_MATCH("Nikon", 5)) {
 		/* There are two scenarios here:
 		 * Type 1:
 		 * :0000: 4E 69 6B 6F 6E 00 01 00-05 00 02 00 02 00 06 00 Nikon...........
@@ -236,11 +239,11 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		 * :0000: 4E 69 6B 6F 6E 00 02 00-00 00 4D 4D 00 2A 00 00 Nikon....MM.*...
 		 * :0010: 00 08 00 1E 00 01 00 07-00 00 00 04 30 32 30 30 ............0200
 		 */
-		if (pval[6] == 1) {
+		if (length >= 7 && pval[6] == 1) {
 			// Nikon type 1 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_NIKONTYPE1;
 			*subdirOffset = 8;
-        } else if (pval[6] == 2) {
+        } else if (length >= 7 && pval[6] == 2) {
             // Nikon type 3 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_NIKONTYPE3;
 			*subdirOffset = 18;
@@ -259,7 +262,7 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		*subdirOffset = 0;
 	} else if(Maker && (FreeImage_strnicmp("Casio", Maker, 5) == 0)) {
         // Casio Makernote
-		if(memcmp("QVC\x00\x00\x00", pval, 6) == 0) {
+		if(MN_MATCH("QVC\x00\x00\x00", 6)) {
 			// Casio Type 2 Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_CASIOTYPE2;
 			*subdirOffset = 6;
@@ -268,17 +271,19 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 			*md_model = TagLib::EXIF_MAKERNOTE_CASIOTYPE1;
 			*subdirOffset = 0;
 		}
-	} else if ((memcmp("FUJIFILM", pval, 8) == 0) || (Maker && (FreeImage_strnicmp("Fujifilm", Maker, 8) == 0))) {
+	} else if (MN_MATCH("FUJIFILM", 8) || (Maker && (FreeImage_strnicmp("Fujifilm", Maker, 8) == 0))) {
         // Fujifile Makernote
-		// Fujifilm's Makernote always use little-endian order altough the Exif section maybe in little-endian order or in big-endian order. 
-		// If msb_order == TRUE, the Makernote won't be read: 
-		// the value of ifdStart will be 0x0c000000 instead of 0x0000000c and the MakerNote section will be 
+		// Fujifilm's Makernote always use little-endian order altough the Exif section maybe in little-endian order or in big-endian order.
+		// If msb_order == TRUE, the Makernote won't be read:
+		// the value of ifdStart will be 0x0c000000 instead of 0x0000000c and the MakerNote section will be
 		// discarded later in jpeg_read_exif_dir because the IFD is too high
 		*md_model = TagLib::EXIF_MAKERNOTE_FUJIFILM;
-        DWORD ifdStart = ReadUint32(msb_order, pval + 8);
-		*subdirOffset = ifdStart;
+		if (length >= 12) {
+			DWORD ifdStart = ReadUint32(msb_order, pval + 8);
+			*subdirOffset = ifdStart;
+		}
     }
-	else if(memcmp("KYOCERA\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x00\x00\x00", pval, 22) == 0) {
+	else if(MN_MATCH("KYOCERA\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x00\x00\x00", 22)) {
 		*md_model = TagLib::EXIF_MAKERNOTE_KYOCERA;
 		*subdirOffset = 22;
 	}
@@ -287,14 +292,14 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 		*md_model = TagLib::EXIF_MAKERNOTE_MINOLTA;
 		*subdirOffset = 0;
 	}
-	else if(memcmp("Panasonic\x00\x00\x00", pval, 12) == 0) {
+	else if(MN_MATCH("Panasonic\x00\x00\x00", 12)) {
 		// Panasonic maker note
 		*md_model = TagLib::EXIF_MAKERNOTE_PANASONIC;
 		*subdirOffset = 12;
 	}
 	else if(Maker && (FreeImage_strnicmp("LEICA", Maker, 5) == 0)) {
 		// Leica maker note
-		if(memcmp("LEICA\x00\x00\x00", pval, 8) == 0) {
+		if(MN_MATCH("LEICA\x00\x00\x00", 8)) {
 			// not yet supported makernote data ignored
 			*md_model = TagLib::UNKNOWN;
 			*subdirOffset = 0;
@@ -302,7 +307,7 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	}
 	else if(Maker && ((FreeImage_strnicmp("Pentax", Maker, 6) == 0) || (FreeImage_strnicmp("Asahi", Maker, 5) == 0))) {
 		// Pentax maker note
-		if(memcmp("AOC\x00", pval, 4) == 0) {
+		if(MN_MATCH("AOC\x00", 4)) {
 			// Type 2 Pentax Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_PENTAX;
 			*subdirOffset = 6;
@@ -311,12 +316,12 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 			*md_model = TagLib::EXIF_MAKERNOTE_ASAHI;
 			*subdirOffset = 0;
 		}
-	}	
-	else if((memcmp("SONY CAM\x20\x00\x00\x00", pval, 12) == 0) || (memcmp("SONY DSC\x20\x00\x00\x00", pval, 12) == 0)) {
+	}
+	else if(MN_MATCH("SONY CAM\x20\x00\x00\x00", 12) || MN_MATCH("SONY DSC\x20\x00\x00\x00", 12)) {
 		*md_model = TagLib::EXIF_MAKERNOTE_SONY;
 		*subdirOffset = 12;
 	}
-	else if((memcmp("SIGMA\x00\x00\x00", pval, 8) == 0) || (memcmp("FOVEON\x00\x00", pval, 8) == 0)) {
+	else if(MN_MATCH("SIGMA\x00\x00\x00", 8) || MN_MATCH("FOVEON\x00\x00", 8)) {
 		FITAG *tagModel = NULL;
 		FreeImage_GetMetadata(FIMD_EXIF_MAIN, dib, "Model", &tagModel);
 		const char *Model = (char*)FreeImage_GetTagValue(tagModel);
@@ -332,16 +337,23 @@ processMakerNote(FIBITMAP *dib, const char *pval, BOOL msb_order, DWORD *subdirO
 	}
 	else if (Maker && (FreeImage_strnicmp("Apple", Maker, 5) == 0)) {
 		// Apple maker note
-		if (memcmp("Apple iOS", pval, 9) == 0) {
+		if (MN_MATCH("Apple iOS", 9)) {
 			// Apple iOS Makernote
 			*md_model = TagLib::EXIF_MAKERNOTE_APPLE_IOS;
 			*subdirOffset = 14;
 		}
 	}
+
+	if (*subdirOffset > length) {
+		*subdirOffset = 0;
+		*md_model = TagLib::UNKNOWN;
+	}
+
+#undef MN_MATCH
 }
 
 /**
-Process a Canon maker note tag. 
+Process a Canon maker note tag.
 A single Canon tag may contain many other tags within.
 
 @param dib Image to be processed
@@ -718,7 +730,7 @@ jpeg_read_exif_dir(FIBITMAP *dib, const BYTE *tiffp, DWORD dwOffsetIfd0, DWORD d
 				
 				// get offset and metadata model
 				if (FreeImage_GetTagID(tag) == TAG_MAKER_NOTE) {
-					processMakerNote(dib, pval, msb_order, &sub_offset, &next_mdmodel);
+					processMakerNote(dib, pval, FreeImage_GetTagLength(tag), msb_order, &sub_offset, &next_mdmodel);
 					next_ifd = (BYTE*)pval + sub_offset;
 				} else {
 					processIFDOffset(tag, pval, msb_order, &sub_offset, &next_mdmodel);
@@ -880,6 +892,10 @@ jpeg_read_exif_profile(FIBITMAP *dib, const BYTE *data, unsigned length) {
 	BYTE *pbProfile = (BYTE*)data;
 
 	// verify the identifying string
+	if(dwProfileLength < sizeof(exif_signature) + 8) {
+		return FALSE;
+	}
+
 	if(memcmp(exif_signature, pbProfile, sizeof(exif_signature)) == 0) {
 		// This is an Exif profile
 		// should contain a TIFF header with up to 2 IFDs (IFD stands for 'Image File Directory')
@@ -891,7 +907,7 @@ jpeg_read_exif_profile(FIBITMAP *dib, const BYTE *data, unsigned length) {
 		// read the TIFF header (8 bytes)
 
 		// check the endianess order
-		
+
 		BOOL bBigEndian = TRUE;
 
 		if(memcmp(pbProfile, lsb_first, sizeof(lsb_first)) == 0) {
@@ -949,7 +965,7 @@ jpeg_read_exif_profile_raw(FIBITMAP *dib, const BYTE *profile, unsigned length) 
     BYTE exif_signature[6] = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
 
 	// verify the identifying string
-	if(memcmp(exif_signature, profile, sizeof(exif_signature)) != 0) {
+	if(length < sizeof(exif_signature) || memcmp(exif_signature, profile, sizeof(exif_signature)) != 0) {
 		// not an Exif profile
 		return FALSE;
 	}

--- a/Source/Metadata/IPTC.cpp
+++ b/Source/Metadata/IPTC.cpp
@@ -127,7 +127,15 @@ read_iptc_profile(FIBITMAP *dib, const BYTE *dataptr, unsigned int datalen) {
 				FreeImage_SetTagType(tag, FIDT_SSHORT);
 				FreeImage_SetTagCount(tag, 1);
 				short *pvalue = (short*)&iptc_value[0];
-				*pvalue = (short)((profile[offset] << 8) | profile[offset + 1]);
+				// tagByteCount is attacker-controlled and only guaranteed to
+				// leave at least 1 byte available (see the bounds check
+				// above) - reading profile[offset + 1] unconditionally can
+				// read one byte past the end of the profile buffer.
+				if (tagByteCount >= 2) {
+					*pvalue = (short)((profile[offset] << 8) | profile[offset + 1]);
+				} else {
+					*pvalue = (short)(profile[offset] << 8);
+				}
 				FreeImage_SetTagValue(tag, pvalue);
 				break;
 			}

--- a/Source/Metadata/IPTC.cpp
+++ b/Source/Metadata/IPTC.cpp
@@ -127,7 +127,11 @@ read_iptc_profile(FIBITMAP *dib, const BYTE *dataptr, unsigned int datalen) {
 				FreeImage_SetTagType(tag, FIDT_SSHORT);
 				FreeImage_SetTagCount(tag, 1);
 				short *pvalue = (short*)&iptc_value[0];
-				*pvalue = (short)((profile[offset] << 8) | profile[offset + 1]);
+				if (tagByteCount >= 2) {
+					*pvalue = (short)((profile[offset] << 8) | profile[offset + 1]);
+				} else {
+					*pvalue = (short)(profile[offset] << 8);
+				}
 				FreeImage_SetTagValue(tag, pvalue);
 				break;
 			}


### PR DESCRIPTION
### CVE triage and fixes

Continues #35's triage.

* **CVE-2024-9029 / CVE-2024-28568 — IPTC**
  * `read_iptc_profile()` no longer reads `profile[offset + 1]` when `TAG_RECORD_VERSION` has `tagByteCount == 1`.

* **CVE-2024-28573 / CVE-2024-28577 — Exif**
  * Bounds-check the APP1 length before the 6-byte `Exif\0\0` compare in `jpeg_read_exif_profile()` and `jpeg_read_exif_profile_raw()`.
  * Require an 8-byte TIFF header after the signature.

* **CVE-2024-28570 — Exif MakerNote**
  * `processMakerNote()` takes the tag length and bounds-checks every fixed-size signature read.
  * Rejects a parsed IFD offset that sits past the MakerNote payload.

* **CVE-2024-28583 — XPM**
  * Pixel rows must be at least `width * cpp` bytes, matching the existing color-table check.

* **CVE-2024-28578 / CVE-2024-28580 — RAS**
  * Overflow-check 24/32bpp row allocations and handle `malloc()` failure.
  * Use `DWORD` for `x`/`y` and `linelength` so widths > 65535 don't wrap.