### PR TITLE
Stop doubling CI runs: scope push trigger to master only

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,13 @@ name: "CMake build"
 
 on:
   push:
+    # unscoped push: would also fire for every push to an open PR's branch,
+    # duplicating the pull_request run below for the same commit. Scoping
+    # to master keeps a post-merge signal without doubling PR CI - the
+    # pull_request run below is the more useful of the two for PR branches
+    # anyway, since it tests the merge commit against current master.
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Every push to an open PR's branch was firing both the unscoped \`push:\` trigger and the \`pull_request:\` trigger for the same commit - two full CI matrices (~24+ jobs each) per push, visible throughout this session as paired run IDs for every PR.

Scopes \`push:\` to \`branches: [master]\`, so PR branches only run once (via \`pull_request:\`, which is also the more useful signal - it tests the merge commit against current \`master\`, not just the raw branch tip). \`master\` itself still gets a \`push\`-triggered run after every merge.