### PR TITLE
Fix remaining issue #35 CVEs: XBM/XPM, TIFF AssignPixel, JPEG source, Canon MakerNote

### DIFF
--- a/Source/FreeImage/PluginJPEG.cpp
+++ b/Source/FreeImage/PluginJPEG.cpp
@@ -215,9 +215,6 @@ empty_output_buffer (j_compress_ptr cinfo) {
 	freeimage_dst_ptr dest = (freeimage_dst_ptr) cinfo->dest;
 
 	if (dest->m_io->write_proc(dest->buffer, 1, OUTPUT_BUF_SIZE, dest->outfile) != OUTPUT_BUF_SIZE) {
-		// let the memory manager delete any temp files before we die
-		jpeg_destroy((j_common_ptr)cinfo);
-
 		JPEG_EXIT((j_common_ptr)cinfo, JERR_FILE_WRITE);
 	}
 
@@ -243,9 +240,6 @@ term_destination (j_compress_ptr cinfo) {
 
 	if (datacount > 0) {
 		if (dest->m_io->write_proc(dest->buffer, 1, (unsigned int)datacount, dest->outfile) != datacount) {
-			// let the memory manager delete any temp files before we die
-			jpeg_destroy((j_common_ptr)cinfo);
-			
 			JPEG_EXIT((j_common_ptr)cinfo, JERR_FILE_WRITE);
 		}
 	}
@@ -288,15 +282,15 @@ METHODDEF(boolean)
 fill_input_buffer (j_decompress_ptr cinfo) {
 	freeimage_src_ptr src = (freeimage_src_ptr) cinfo->src;
 
+	if (!src->buffer) {
+		JPEG_EXIT((j_common_ptr)cinfo, JERR_INPUT_EMPTY);
+	}
+
 	size_t nbytes = src->m_io->read_proc(src->buffer, 1, INPUT_BUF_SIZE, src->infile);
 
 	if (nbytes <= 0) {
 		if (src->start_of_file)	{
 			// treat empty input file as fatal error
-
-			// let the memory manager delete any temp files before we die
-			jpeg_destroy((j_common_ptr)cinfo);
-
 			JPEG_EXIT((j_common_ptr)cinfo, JERR_INPUT_EMPTY);
 		}
 
@@ -341,6 +335,9 @@ skip_input_data (j_decompress_ptr cinfo, long num_bytes) {
 		  num_bytes -= (long) src->pub.bytes_in_buffer;
 
 		  (void) fill_input_buffer(cinfo);
+		  if (src->pub.bytes_in_buffer == 0) {
+			  return;
+		  }
 
 		  /* note we assume that fill_input_buffer will never return FALSE,
 		   * so suspension need not be handled.

--- a/Source/FreeImage/PluginTIFF.cpp
+++ b/Source/FreeImage/PluginTIFF.cpp
@@ -78,6 +78,38 @@ typedef enum {
 	LoadAsHalfFloat		= 6
 } TIFFLoadMethod;
 
+static void
+AssignContigRow(BYTE *dst, const BYTE *src, tmsize_t src_line, unsigned dst_bpp, unsigned src_bpp, uint32_t width) {
+	if (!dst || !src || dst_bpp == 0) {
+		return;
+	}
+	const BYTE *const src_end = src + src_line;
+	for (uint32_t x = 0; x < width; x++) {
+		if ((src_end < src) || ((size_t)(src_end - src) < dst_bpp)) {
+			break;
+		}
+		AssignPixel(dst, src, dst_bpp);
+		dst += dst_bpp;
+		src += src_bpp;
+	}
+}
+
+static void
+AssignPlanarRow(BYTE *dst, const BYTE *src, tmsize_t src_line, unsigned dst_bpp, unsigned src_bpp, unsigned channelOffset, uint32_t width) {
+	if (!dst || !src || src_bpp == 0) {
+		return;
+	}
+	const BYTE *const src_end = src + src_line;
+	for (uint32_t x = 0; x < width; x++) {
+		if ((src_end < src) || ((size_t)(src_end - src) < src_bpp)) {
+			break;
+		}
+		AssignPixel(dst + channelOffset, src, src_bpp);
+		dst += dst_bpp;
+		src += src_bpp;
+	}
+}
+
 // ----------------------------------------------------------
 //   local prototypes
 // ----------------------------------------------------------
@@ -1808,21 +1840,27 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 						if(src_line != dst_line) {
 							// CMYKA+
 							if(alpha) {
+								const unsigned extra = (Bpc > 1) ? 2 : 1;
 								for (int l = 0; l < strips; l++) {
-									for(BYTE *pixel = bits, *al_pixel = alpha_bits, *src_pixel =  buf + l * src_line; pixel < bits + dib_pitch; pixel += dibBpp, al_pixel += alpha_Bpp, src_pixel += srcBpp) {
-										// copy pixel byte by byte
-										BYTE b = 0;
-										for( ; b < dibBpp; ++b) {
-											pixel[b] =  src_pixel[b];
+									BYTE *pixel = bits;
+									BYTE *al_pixel = alpha_bits;
+									const BYTE *src_pixel = buf + l * src_line;
+									const BYTE *const src_end = src_pixel + src_line;
+									for (uint32_t x = 0; x < width; x++) {
+										if ((src_end < src_pixel) || ((size_t)(src_end - src_pixel) < (dibBpp + extra))) {
+											break;
 										}
-										// TODO write the remaining bytes to extra channel(s)
-
+										for (unsigned b = 0; b < dibBpp; ++b) {
+											pixel[b] = src_pixel[b];
+										}
 										// HACK write the first alpha to a separate dib (assume BYTE or WORD)
-										al_pixel[0] = src_pixel[b];
-										if(Bpc > 1) {
-											al_pixel[1] = src_pixel[b + 1];
+										al_pixel[0] = src_pixel[dibBpp];
+										if (Bpc > 1) {
+											al_pixel[1] = src_pixel[dibBpp + 1];
 										}
-
+										pixel += dibBpp;
+										al_pixel += alpha_Bpp;
+										src_pixel += srcBpp;
 									}
 									bits -= dib_pitch;
 									alpha_bits -= alpha_pitch;
@@ -1831,9 +1869,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 							else {
 								// alpha/extra channels alloc failed
 								for (int l = 0; l < strips; l++) {
-									for(BYTE* pixel = bits, * src_pixel =  buf + l * src_line; pixel < bits + dst_line; pixel += dibBpp, src_pixel += srcBpp) {
-										AssignPixel(pixel, src_pixel, dibBpp);
-									}
+									AssignContigRow(bits, buf + l * src_line, src_line, dibBpp, srcBpp, width);
 									bits -= dib_pitch;
 								}
 							}
@@ -1899,13 +1935,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 							BYTE *src_line_begin = buf;
 							BYTE *dst_line_begin = dst_strip;
 							for (int l = 0; l < strips; l++, src_line_begin += src_line, dst_line_begin -= dst_pitch ) {
-								// - loop for pixels in strip -
-
-								const BYTE* const src_line_end = src_line_begin + src_line;
-								for (BYTE *src_bits = src_line_begin, * dst_bits = dst_line_begin; src_bits < src_line_end; src_bits += Bpc, dst_bits += Bpp) {
-									AssignPixel(dst_bits + channelOffset, src_bits, Bpc);
-								} // line
-
+								AssignPlanarRow(dst_line_begin, src_line_begin, src_line, Bpp, Bpc, channelOffset, width);
 							} // strips
 
 						} // channels
@@ -2014,9 +2044,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 						}
 						else {
 							for (int l = 0; l < strips; l++) {
-								for(BYTE *pixel = bits, *src_pixel =  buf + l * src_line; pixel < bits + dst_pitch; pixel += Bpp, src_pixel += srcBpp) {
-									AssignPixel(pixel, src_pixel, Bpp);
-								}
+								AssignContigRow(bits, buf + l * src_line, src_line, Bpp, srcBpp, width);
 								bits -= dst_pitch;
 							}
 						}
@@ -2052,16 +2080,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 							BYTE* src_line_begin = buf;
 							BYTE* dst_line_begin = dib_strip;
 							for (int l = 0; l < strips; l++, src_line_begin += src_line, dst_line_begin -= dst_pitch ) {
-
-								// - loop for pixels in strip -
-
-								const BYTE* const src_line_end = src_line_begin + src_line;
-
-								for (BYTE* src_bits = src_line_begin, * dst_bits = dst_line_begin; src_bits < src_line_end; src_bits += Bpc, dst_bits += Bpp) {
-									// actually assigns channel
-									AssignPixel(dst_bits + channelOffset, src_bits, Bpc);
-								} // line
-
+								AssignPlanarRow(dst_line_begin, src_line_begin, src_line, Bpp, Bpc, channelOffset, width);
 							} // strips
 
 						} // channels

--- a/Source/FreeImage/PluginXBM.cpp
+++ b/Source/FreeImage/PluginXBM.cpp
@@ -53,14 +53,21 @@ The result stored in str is appended with a null character.
 */
 static char* 
 readLine(char *str, int n, FreeImageIO *io, fi_handle handle) {
-	char c;
-	int count, i = 0;
+	char c = 0;
+	int count = 0, i = 0;
+	if (n <= 1) {
+		return NULL;
+	}
 	do {
 		count = io->read_proc(&c, 1, 1, handle);
+		if (count <= 0) {
+			if (i == 0) {
+				return NULL;
+			}
+			break;
+		}
 		str[i++] = c;
-	} while((c != '\n') && (i < n));
-	if(count <= 0)
-		return NULL;
+	} while((c != '\n') && (i < n - 1));
 	str[i] = '\0';
 	return str;
 }
@@ -294,7 +301,7 @@ MimeType() {
 static BOOL DLL_CALLCONV
 Validate(FreeImageIO *io, fi_handle handle) {
 	char magic[8];
-	if(readLine(magic, 7, io, handle)) {
+	if(readLine(magic, (int)sizeof(magic), io, handle)) {
 		if(strcmp(magic, "#define") == 0)
 			return TRUE;
 	}

--- a/Source/FreeImage/PluginXPM.cpp
+++ b/Source/FreeImage/PluginXPM.cpp
@@ -278,7 +278,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 					}
 
 					if (!FreeImage_LookupX11Color(clr,  &rgba.r, &rgba.g, &rgba.b)) {
-						sprintf(msg, "Unknown color name '%s'", str);
+						snprintf(msg, sizeof(msg), "Unknown color name '%s'", str);
 						free(str);
 						throw msg;
 					}

--- a/Source/Metadata/Exif.cpp
+++ b/Source/Metadata/Exif.cpp
@@ -370,61 +370,77 @@ processCanonMakerNoteTag(FIBITMAP *dib, FITAG *tag) {
 
 	int subTagTypeBase = 0;
 
+	BOOL expand_shorts = FALSE;
+
 	switch(tag_id) {
 		case TAG_CANON_CAMERA_STATE_0x01:
 			subTagTypeBase = 0xC100;
 			startIndex = 1;
+			expand_shorts = TRUE;
 			break;
 		case TAG_CANON_CAMERA_STATE_0x02:
 			subTagTypeBase = 0xC200;
 			startIndex = 0;
+			expand_shorts = TRUE;
 			break;
 		case TAG_CANON_CAMERA_STATE_0x04:
 			subTagTypeBase = 0xC400;
 			startIndex = 1;
+			expand_shorts = TRUE;
 			break;
 		case TAG_CANON_CAMERA_STATE_0x12:
 			subTagTypeBase = 0x1200;
 			startIndex = 0;
+			expand_shorts = TRUE;
 			break;
 		case TAG_CANON_CAMERA_STATE_0xA0:
 			subTagTypeBase = 0xCA00;
 			startIndex = 1;
+			expand_shorts = TRUE;
 			break;
 		case TAG_CANON_CAMERA_STATE_0xE0:
 			subTagTypeBase = 0xCE00;
 			startIndex = 1;
+			expand_shorts = TRUE;
 			break;
-
-		default:
-		{
-			// process as a normal tag
-
-			// get the tag key and description
-			const char *key = s.getTagFieldName(TagLib::EXIF_MAKERNOTE_CANON, tag_id, defaultKey);
-			FreeImage_SetTagKey(tag, key);
-			const char *description = s.getTagDescription(TagLib::EXIF_MAKERNOTE_CANON, tag_id);
-			FreeImage_SetTagDescription(tag, description);
-
-			// store the tag
-			if(key) {
-				FreeImage_SetMetadata(FIMD_EXIF_MAKERNOTE, dib, key, tag);
-			}
-
-			return TRUE;
-		}
-		break;
-
 	}
 
-	WORD *pvalue = (WORD*)FreeImage_GetTagValue(tag);
+	WORD *pvalue = NULL;
+	DWORD wordCount = 0;
+	if (expand_shorts
+		&& ((FreeImage_GetTagType(tag) == FIDT_SHORT) || (FreeImage_GetTagType(tag) == FIDT_SSHORT))
+		&& FreeImage_GetTagValue(tag)) {
+		pvalue = (WORD*)FreeImage_GetTagValue(tag);
+		wordCount = FreeImage_GetTagLength(tag) / sizeof(WORD);
+		DWORD count = FreeImage_GetTagCount(tag);
+		if (count < wordCount) {
+			wordCount = count;
+		}
+	}
+
+	if (!pvalue) {
+		// process as a normal tag
+
+		// get the tag key and description
+		const char *key = s.getTagFieldName(TagLib::EXIF_MAKERNOTE_CANON, tag_id, defaultKey);
+		FreeImage_SetTagKey(tag, key);
+		const char *description = s.getTagDescription(TagLib::EXIF_MAKERNOTE_CANON, tag_id);
+		FreeImage_SetTagDescription(tag, description);
+
+		// store the tag
+		if(key) {
+			FreeImage_SetMetadata(FIMD_EXIF_MAKERNOTE, dib, key, tag);
+		}
+
+		return TRUE;
+	}
 
 	// create a tag
 	FITAG *canonTag = FreeImage_CreateTag();
 	if(!canonTag) return FALSE;
 
 	// we intentionally skip the first array member (if needed)
-    for (DWORD i = startIndex; i < FreeImage_GetTagCount(tag); i++) {
+    for (DWORD i = startIndex; i < wordCount; i++) {
 
 		tag_id = (WORD)(subTagTypeBase + i);
 

--- a/Source/Metadata/FreeImageTag.cpp
+++ b/Source/Metadata/FreeImageTag.cpp
@@ -254,7 +254,10 @@ FreeImage_SetTagValue(FITAG *tag, const void *value) {
 	if(tag && value) {
 		FITAGHEADER *tag_header = (FITAGHEADER *)tag->data;
 		// first, check the tag
-		if(tag_header->count * FreeImage_TagDataWidth((FREE_IMAGE_MDTYPE)tag_header->type) != tag_header->length) {
+		const unsigned type_width = FreeImage_TagDataWidth((FREE_IMAGE_MDTYPE)tag_header->type);
+		if ((type_width == 0) ||
+			(tag_header->count > (~(DWORD)0 / type_width)) ||
+			(tag_header->count * type_width != tag_header->length)) {
 			// invalid data count ?
 			return FALSE;
 		}


### PR DESCRIPTION
Continues #35 after #96.

* **CVE-2024-28583 — XBM `readLine()`**
  * `n` is the destination buffer size. Leave room for the terminating NUL so a `MAX_LINE`-byte line cannot write `str[MAX_LINE]`.
  * `Validate()` passes `sizeof(magic)`.

* **XPM unknown-color error (same Ruanxingzhi report as 28583)**
  * `snprintf` into `msg[256]` instead of `sprintf`, so a long color name cannot smash the stack.

* **CVE-2024-28566 — TIFF `AssignPixel()`**
  * Generic-strip contig copies iterated to `dst_pitch`, so 4-byte alignment padding read/wrote past the source strip.
  * Bound contig and planar copies by image width and remaining source-row bytes.

* **CVE-2024-28571 — JPEG `fill_input_buffer()`**
  * Do not `jpeg_destroy()` before `JPEG_EXIT`. `jpeg_error_exit` already destroys; using `cinfo` after destroy is a use-after-free.
  * Same pattern removed from the JPEG destination manager. Guard `skip_input_data` against a zero-length fill.

* **CVE-2024-28572 — `FreeImage_SetTagValue()` via Canon MakerNote**
  * `processCanonMakerNoteTag()` only expands camera-state tags that are actually `SHORT`/`SSHORT`, and caps the loop at `min(count, length/2)`.
  * `FreeImage_SetTagValue()` rejects `count * type_width` overflow.

Fixes #35 once this lands (OpenEXR/OpenJPEG items were already replaced by the vendor bumps).