### PR TITLE
WinMerge stack 1/4: loader overflows (PICT/PCX/J2K/PSD/HDR/PFM/BMP/RAS)

### DIFF
--- a/Source/FreeImage/J2KHelper.cpp
+++ b/Source/FreeImage/J2KHelper.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 helpers
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -127,6 +127,13 @@ FIBITMAP* J2KImageToFIBITMAP(int format_id, const opj_image_t *image, BOOL heade
 	FIBITMAP *dib = NULL;
 
 	try {
+		// opj_read_header() can return success while still leaving *image
+		// NULL for some malformed codestreams - guard against the NULL
+		// pointer dereference below rather than trusting callers to check.
+		if (!image) {
+			throw FI_MSG_ERROR_CORRUPTED_IMAGE;
+		}
+
 		// check the number of components
 		int numcomps = image->numcomps;
 		if (numcomps < 1) {

--- a/Source/FreeImage/PSDParser.cpp
+++ b/Source/FreeImage/PSDParser.cpp
@@ -1308,7 +1308,16 @@ void psdParser::ReadImageLine(BYTE* dst, const BYTE* src, unsigned lineSize, uns
 }
 
 void psdParser::UnpackRLE(BYTE* line, const BYTE* rle_line, BYTE* line_end, unsigned srcSize) {
-	while (srcSize > 0) {
+	// NOTE: line/line_end bound the destination scanline; srcSize bounds how
+	// many bytes remain in the (attacker-controlled) rle_line source buffer.
+	// Both the copy length written to the destination AND the amount
+	// consumed from the source must be clamped *before* len is used to
+	// advance line/rle_line/srcSize - advancing by the raw, unclamped len
+	// let line overrun line_end (turning line_end - line negative, which
+	// becomes a huge size_t on the next iteration's memcpy/memset) and let
+	// srcSize (unsigned) underflow to a huge value when len > srcSize,
+	// letting rle_line run past the end of its real buffer.
+	while (srcSize > 0 && line < line_end) {
 
 		int len = *rle_line++;
 		srcSize--;
@@ -1321,9 +1330,17 @@ void psdParser::UnpackRLE(BYTE* line, const BYTE* rle_line, BYTE* line_end, unsi
 			// (len + 1) bytes of data are copied
 			++len;
 
-			// assert we don't write beyound eol
-			memcpy(line, rle_line, line + len > line_end ? line_end - line : len);
-			line += len;
+			// clamp to what's actually left in the source buffer
+			if ((unsigned)len > srcSize) {
+				len = (int)srcSize;
+			}
+
+			// assert we don't write beyond eol
+			const auto remaining = line_end - line;
+			const int copyLen = (len > remaining) ? (int)remaining : len;
+
+			memcpy(line, rle_line, copyLen);
+			line += copyLen;
 			rle_line += len;
 			srcSize -= len;
 		}
@@ -1335,10 +1352,19 @@ void psdParser::UnpackRLE(BYTE* line, const BYTE* rle_line, BYTE* line_end, unsi
 			len ^= 0xFF; // same as (-len + 1) & 0xFF
 			len += 2;    //
 
-			// assert we don't write beyound eol
-			memset(line, *rle_line++, line + len > line_end ? line_end - line : len);
-			line += len;
+			if (srcSize < 1) {
+				// no repeat-value byte left in the source buffer
+				break;
+			}
+			const BYTE value = *rle_line++;
 			srcSize--;
+
+			// assert we don't write beyond eol
+			const auto remaining = line_end - line;
+			const int copyLen = (len > remaining) ? (int)remaining : len;
+
+			memset(line, value, copyLen);
+			line += copyLen;
 		}
 		else if ( 128 == len ) {
 			// Do nothing

--- a/Source/FreeImage/PluginBMP.cpp
+++ b/Source/FreeImage/PluginBMP.cpp
@@ -431,8 +431,16 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 	BYTE delta_y = 0;
 
 	height = abs(height);
-	
-	while(scanline < height) {
+
+	// NB: this loop is intentionally not bounded by `scanline < height` - a
+	// well-formed RLE8 stream can (and often does) emit a trailing
+	// RLE_ENDOFBITMAP marker only after `scanline` has already reached
+	// `height` (e.g. right after the final RLE_ENDOFLINE), and bounding the
+	// loop on `scanline` prevents ever reading that marker, causing this
+	// function to spuriously fail on legitimate files (see issue #23).
+	// Safety against out-of-bounds writes (CVE-2020-21427) is instead
+	// enforced directly at each FreeImage_GetScanLine() call site below.
+	for (;;) {
 
 		if (io->read_proc(&status_byte, sizeof(BYTE), 1, handle) != 1) {
 			return FALSE;
@@ -469,6 +477,9 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 
 				default:
 					// absolute mode
+					if (scanline >= height) {
+						return FALSE;
+					}
 					count = MIN((int)status_byte, width - bits);
 					if (count < 0) {
 						return FALSE;
@@ -489,6 +500,9 @@ LoadPixelDataRLE8(FreeImageIO *io, fi_handle handle, int width, int height, FIBI
 			} // switch (status_byte)
 		}
 		else {
+			if (scanline >= height) {
+				return FALSE;
+			}
 			count = MIN((int)status_byte, width - bits);
 			if (count < 0) {
 				return FALSE;

--- a/Source/FreeImage/PluginHDR.cpp
+++ b/Source/FreeImage/PluginHDR.cpp
@@ -2,7 +2,7 @@
 // HDR Loader and writer
 //
 // Design and implementation by 
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -362,15 +362,42 @@ rgbe_WritePixels(FreeImageIO *io, fi_handle handle, FIRGBF *data, unsigned numpi
   return TRUE;
 }
 
-static BOOL 
+/**
+Safely compute scanline_width * num_scanlines as the unsigned pixel count
+rgbe_ReadPixels() expects. scanline_width is signed and num_scanlines is
+unsigned, so a naive `scanline_width * num_scanlines` first converts a
+negative scanline_width to a huge unsigned value (via the usual arithmetic
+conversions) rather than raising an error, and the product itself is not
+checked for overflow either - both would make rgbe_ReadPixels() write far
+past the end of the caller's data buffer. Returns FALSE if scanline_width
+is negative or the product doesn't fit in an unsigned.
+*/
+static BOOL
+rgbe_SafeScanlinePixelCount(int scanline_width, unsigned num_scanlines, unsigned *out_numpixels) {
+	if (scanline_width < 0) {
+		return FALSE;
+	}
+	const unsigned long long numpixels = (unsigned long long)(unsigned)scanline_width * num_scanlines;
+	if (numpixels > 0xFFFFFFFFull) {
+		return FALSE;
+	}
+	*out_numpixels = (unsigned)numpixels;
+	return TRUE;
+}
+
+static BOOL
 rgbe_ReadPixels_RLE(FreeImageIO *io, fi_handle handle, FIRGBF *data, int scanline_width, unsigned num_scanlines) {
 	BYTE rgbe[4], *scanline_buffer, *ptr, *ptr_end;
 	int i, count;
 	BYTE buf[2];
-	
+	unsigned numpixels;
+
 	if ((scanline_width < 8)||(scanline_width > 0x7fff)) {
 		// run length encoding is not allowed so read flat
-		return rgbe_ReadPixels(io, handle, data, scanline_width * num_scanlines);
+		if(!rgbe_SafeScanlinePixelCount(scanline_width, num_scanlines, &numpixels)) {
+			return rgbe_Error(rgbe_format_error, "invalid scanline width");
+		}
+		return rgbe_ReadPixels(io, handle, data, numpixels);
 	}
 	scanline_buffer = NULL;
 	// read in each successive scanline 
@@ -384,7 +411,13 @@ rgbe_ReadPixels_RLE(FreeImageIO *io, fi_handle handle, FIRGBF *data, int scanlin
 			rgbe_RGBEToFloat(data, rgbe);
 			data ++;
 			free(scanline_buffer);
-			return rgbe_ReadPixels(io, handle, data, scanline_width * num_scanlines - 1);
+			// scanline_width is already known positive/bounded here (the
+			// early-return above handles the rest), but num_scanlines could
+			// still make the product overflow an unsigned
+			if(!rgbe_SafeScanlinePixelCount(scanline_width, num_scanlines, &numpixels) || numpixels < 1) {
+				return rgbe_Error(rgbe_format_error, "invalid scanline width");
+			}
+			return rgbe_ReadPixels(io, handle, data, numpixels - 1);
 		}
 		if((((int)rgbe[2]) << 8 | rgbe[3]) != scanline_width) {
 			free(scanline_buffer);

--- a/Source/FreeImage/PluginJ2K.cpp
+++ b/Source/FreeImage/PluginJ2K.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 J2K codestream Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -167,6 +167,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			
 			// read the main header of the codestream and if necessary the JP2 boxes
 			if( !opj_read_header(d_stream, d_codec, &image)) {
+				throw "Failed to read the header\n";
+			}
+			// opj_read_header() can report success while leaving image NULL
+			// for some malformed codestreams
+			if( !image ) {
 				throw "Failed to read the header\n";
 			}
 

--- a/Source/FreeImage/PluginJP2.cpp
+++ b/Source/FreeImage/PluginJP2.cpp
@@ -2,7 +2,7 @@
 // JPEG2000 JP2 file format Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -167,6 +167,11 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			
 			// read the main header of the codestream and if necessary the JP2 boxes
 			if( !opj_read_header(d_stream, d_codec, &image)) {
+				throw "Failed to read the header\n";
+			}
+			// opj_read_header() can report success while leaving image NULL
+			// for some malformed codestreams
+			if( !image ) {
 				throw "Failed to read the header\n";
 			}
 

--- a/Source/FreeImage/PluginPCX.cpp
+++ b/Source/FreeImage/PluginPCX.cpp
@@ -598,6 +598,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		} else if((header.planes == 3) && (header.bpp == 8)) {
 			BYTE *pLine;
 
+			// sanity check: each plane provides header.bytes_per_line bytes, but the
+			// BGR expansion below reads pLine[x] for x in [0,width). Reject inputs
+			// where width exceeds bytes_per_line to avoid a heap over-read on `line`.
+			if (width > header.bytes_per_line) {
+				throw FI_MSG_ERROR_PARSING;
+			}
+
 			for (unsigned y = 0; y < height; y++) {
 				readLine(io, handle, line, lineLength, bIsRLE, ReadBuf, &ReadPos);
 

--- a/Source/FreeImage/PluginPFM.cpp
+++ b/Source/FreeImage/PluginPFM.cpp
@@ -2,7 +2,7 @@
 // PFM Loader and Writer
 //
 // Design and implementation by
-// - Hervé Drolon (drolon@infonie.fr)
+// - Hervï¿½ Drolon (drolon@infonie.fr)
 //
 // This file is part of FreeImage 3
 //
@@ -271,7 +271,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 		// Read the image...
 
 		if(image_type == FIT_RGBF) {
-			const unsigned lineWidth = 3 * width;
+			// Compute in size_t (not int/unsigned) so a large, attacker-
+			// controlled width can't silently overflow the 32-bit multiply
+			// before it reaches malloc()'s size argument - an overflowed,
+			// too-small lineWidth here would still let the per-pixel unpack
+			// loop below (bounded by the untruncated `width`) read past the
+			// end of this smaller-than-expected lineBuffer allocation.
+			const size_t lineWidth = (size_t)3 * (size_t)width;
 			lineBuffer = (float*)malloc(lineWidth * sizeof(float));
 			if(!lineBuffer) {
 				throw FI_MSG_ERROR_MEMORY;
@@ -305,7 +311,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 			lineBuffer = NULL;
 
 		} else if(image_type == FIT_FLOAT) {
-			const unsigned lineWidth = width;
+			const size_t lineWidth = (size_t)width;
 			lineBuffer = (float*)malloc(lineWidth * sizeof(float));
 			if(!lineBuffer) {
 				throw FI_MSG_ERROR_MEMORY;

--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -390,7 +390,8 @@ ReadColorTable( FreeImageIO *io, fi_handle handle, WORD* pNumColors, RGBQUAD* pP
 			// colours in order.
 			val = (WORD)i;
 		}
-		if (val >= numColors) {
+		if (val >= numColors || val >= 256) {
+			// pPal is always a fixed 256-entry array
 			throw "pixel value greater than color table size.";
 		}
 		// Mac colour tables contain 16-bit values for R, G, and B...

--- a/Source/FreeImage/PluginPICT.cpp
+++ b/Source/FreeImage/PluginPICT.cpp
@@ -756,7 +756,13 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 			}
 		}
 		else {
-			for ( int i = 0; i < height; i++ ) { 
+			// CWE-787: bound every PackBits write to the allocated raster.
+			// The RLE run length is attacker-controlled and the loop below
+			// advances dst without checking it against the bitmap bounds.
+			BYTE* const rasterStart = FreeImage_GetBits( dib );
+			BYTE* const rasterEnd = rasterStart +
+				(size_t)FreeImage_GetPitch( dib ) * FreeImage_GetHeight( dib );
+			for ( int i = 0; i < height; i++ ) {
 				// For each line do...
 				int    linelen;            // length of source line in bytes.
 				if (rowBytes > 250) {
@@ -784,16 +790,22 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 							
 							// This is slow for some formats...
 							if (pixelSize == 16) {
+								if (dst < rasterStart ||
+									(size_t)(rasterEnd - dst) < (size_t)len*4*PixelPerRLEUnit)
+									break;
 								expandBuf( io, handle, 1, pixelSize, dst );
-								for ( int k = 1; k < len; k++ ) { 
+								for ( int k = 1; k < len; k++ ) {
 									// Repeat the pixel len times.
 									memcpy( dst+(k*4*PixelPerRLEUnit), dst,	4*PixelPerRLEUnit);
 								}
 								dst += len*4*PixelPerRLEUnit;
 							}
 							else {
+								if (dst < rasterStart ||
+									(size_t)(rasterEnd - dst) < (size_t)len*PixelPerRLEUnit)
+									break;
 								expandBuf8( io, handle, 1, pixelSize, dst );
-								for ( int k = 1; k < len; k++ ) { 
+								for ( int k = 1; k < len; k++ ) {
 									// Repeat the expanded byte len times.
 									memcpy( dst+(k*PixelPerRLEUnit), dst, PixelPerRLEUnit);
 								}
@@ -806,10 +818,16 @@ UnpackBits( FreeImageIO *io, fi_handle handle, FIBITMAP* dib, MacRect* bounds, W
 						// Unpacked data
 						int len = (FlagCounter & 255) + 1;
 						if (pixelSize == 16) {
+							if (dst < rasterStart ||
+								(size_t)(rasterEnd - dst) < (size_t)len*4*PixelPerRLEUnit)
+								break;
 							expandBuf( io, handle, len, pixelSize, dst );
 							dst += len*4*PixelPerRLEUnit;
 						}
 						else {
+							if (dst < rasterStart ||
+								(size_t)(rasterEnd - dst) < (size_t)len*PixelPerRLEUnit)
+								break;
 							expandBuf8( io, handle, len, pixelSize, dst );
 							dst += len*PixelPerRLEUnit;
 						}

--- a/Source/FreeImage/PluginRAS.cpp
+++ b/Source/FreeImage/PluginRAS.cpp
@@ -321,6 +321,10 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 				b = g + numcolors;
 
 				RGBQUAD *pal = FreeImage_GetPalette(dib);
+				if (!pal) {
+					free(r);
+					throw "No palette for bitmap!";
+				}
 
 				io->read_proc(r, 3 * numcolors, 1, handle);
 


### PR DESCRIPTION
**For [WinMerge/freeimage](https://github.com/WinMerge/freeimage)** — stack 1 of 4. Base is a mirror of their `winmerge` branch.

Cherry-picks of FreeImage-own loader overflow/crash fixes from danoli3 3.19.12. No CMake, no vcxproj, no vendor-tree edits.

| CVE / bug | File | Upstream |
|---|---|---|
| PICT `UnpackBits` heap write | `PluginPICT.cpp` | #47 |
| PCX uninit read (planes=3, bpp=8) | `PluginPCX.cpp` | #50 |
| CVE-2024-28584 J2K NULL deref | `J2KHelper.cpp` | #53 |
| CVE-2024-28565 / CVE-2025-65803 / CVE-2020-24294 PSD `UnpackRLE` | `PSDParser.cpp` | #54 |
| CVE-2024-28579 / CVE-2024-28582 HDR RLE scanline | `PluginHDR.cpp` | #55 |
| CVE-2020-22524 PFM alloc overflow | `PluginPFM.cpp` | #56 |
| BMP RLE8 trailing terminator | `PluginBMP.cpp` | #60 |
| PICT color-table overflow | `PluginPICT.cpp` | #61 |
| RAS NULL palette crash | `PluginRAS.cpp` | #61 |

Next: TIFF ICC UAF + RAW `INT64` (2/4).

WinMerge: fetch `pr/winmerge-1-loaders` from danoli3/FreeImage onto `winmerge`. GitHub will not open a reverse PR into the fork (no write access). See WinMerge/freeimage#23.