### PR TITLE
WinMerge stack 2/4: TIFF ICC use-after-free + RAW INT64 clash

### DIFF
--- a/Source/FreeImage/PluginRAW.cpp
+++ b/Source/FreeImage/PluginRAW.cpp
@@ -23,6 +23,19 @@
 
 #include "../LibRawLite/libraw/libraw.h"
 
+// libraw_types.h just typedef'd INT64/UINT64 as real C++ types (long long /
+// unsigned long long). FreeImage.h's own #ifndef INT64 guard only detects a
+// prior macro, not a typedef, so without this it would go on to #define
+// INT64 int64_t - on platforms where int64_t isn't long long (e.g. Linux,
+// where it's long), that turns LibRaw_freeimage_datastream's overrides
+// below into a different type than the LibRaw_abstract_datastream virtuals
+// they're meant to override. Pre-defining these as self-referential (a
+// same-name object-like macro expands to itself, i.e. a no-op) satisfies
+// the guard while leaving every "INT64"/"UINT64" token to resolve via the
+// real typedef instead.
+#define INT64 INT64
+#define UINT64 UINT64
+
 #include "FreeImage.h"
 #include "Utilities.h"
 #include "../Metadata/FreeImageTag.h"

--- a/Source/FreeImage/PluginTIFF.cpp
+++ b/Source/FreeImage/PluginTIFF.cpp
@@ -2314,6 +2314,13 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 
 		// copy ICC profile data (must be done after FreeImage_Allocate)
 
+		// ReadMetadata() -> tiff_read_exif_profile() may call TIFFReadEXIFDirectory()
+		// when the file has an ExifIFD, which switches libtiff to a different IFD and
+		// back, invalidating the iccBuf pointer fetched above (it points into libtiff's
+		// per-directory field storage). Re-fetch it now that we're back on the main IFD.
+		if (iccBuf) {
+			TIFFGetField(tif, TIFFTAG_ICCPROFILE, &iccSize, &iccBuf);
+		}
 		FreeImage_CreateICCProfile(dib, iccBuf, iccSize);
 		if (photometric == PHOTOMETRIC_SEPARATED) {
 			if (asCMYK) {


### PR DESCRIPTION
**For [WinMerge/freeimage](https://github.com/WinMerge/freeimage)** — stack 2 of 4. Stacked on #100.

| CVE / bug | File | Upstream |
|---|---|---|
| CVE-2024-28567 TIFF ICC UAF after ExifIFD | `PluginTIFF.cpp` | #79 |
| `INT64` macro/typedef clash on GCC/Linux | `PluginRAW.cpp` | #80-adjacent |

Keeps WinMerge's `tiffiop.h` include; only adds the ICC pointer re-fetch after `ReadMetadata()`.

Next: IPTC/Exif/XPM/RAS (#96) as 3/4.