### PR TITLE
CVE-2020-24292: reject illegal ICO BITMAPINFOHEADER bpp/size

### DIFF
--- a/Source/FreeImage/PluginICO.cpp
+++ b/Source/FreeImage/PluginICO.cpp
@@ -303,6 +303,17 @@ LoadStandardIcon(FreeImageIO *io, fi_handle handle, int flags, BOOL header_only)
 	int width  = bmih.biWidth;
 	int height = bmih.biHeight / 2; // height == xor + and mask
 	unsigned bit_count = bmih.biBitCount;
+
+	// ICO BITMAPINFOHEADER must use a real Windows bpp. Illegal values
+	// make CalculateLine/pitch disagree with the allocated DIB (CVE-2020-24292).
+	if (bit_count != 1 && bit_count != 2 && bit_count != 4 && bit_count != 8 &&
+		bit_count != 16 && bit_count != 24 && bit_count != 32) {
+		return NULL;
+	}
+	if ((width <= 0) || (height <= 0)) {
+		return NULL;
+	}
+
 	unsigned line   = CalculateLine(width, bit_count);
 	unsigned pitch  = CalculatePitch(line);
 


### PR DESCRIPTION
Fixes #105
Fixes CVE-2020-24292

## Summary

`LoadStandardIcon()` copied `BITMAPINFOHEADER.biBitCount` / `biWidth` / `biHeight` into `CalculateLine` / `AllocateHeader` / `read_proc` with no check that they describe a real Windows icon. An illegal bpp makes line/pitch disagree with the allocated DIB; a non-positive width or `height/2` then lets the XOR-mask read and the AND-mask loop walk off the heap.

## Change

Reject bpp outside `{1,2,4,8,16,24,32}` and non-positive dimensions **before** any size math. Same approach as the Fedora/Buildroot downstream patch.

## Attack vector

A crafted `.ico` loaded via `FreeImage_Load*` is enough. NVD 8.8 High (`AV:N/AC:L/PR:N/UI:R`).

## Stack

Merge in order (plain-git stack, Graphite not installed):

1. **This PR** #108 — ICO (`#105`) ← `master`
2. #109 — PSD thumbnail (`#106`) ← this branch
3. #110 — PSD `ReadImageLine` (`#107`) ← #109