### PR TITLE
CVE-2020-24293: bound psdThumbnail::Read packed-row copy

### DIFF
--- a/Source/FreeImage/PSDParser.cpp
+++ b/Source/FreeImage/PSDParser.cpp
@@ -780,6 +780,7 @@ int psdThumbnail::Read(FreeImageIO *io, fi_handle handle, int iResourceSize, boo
 
 	if(_dib) {
 		FreeImage_Unload(_dib);
+		_dib = NULL;
 	}
 
 	if(_Format == 1) {
@@ -793,14 +794,43 @@ int psdThumbnail::Read(FreeImageIO *io, fi_handle handle, int iResourceSize, boo
 	}
 	else {
 		// kRawRGB thumbnail image
+		// Header fields are attacker-controlled. packed row bytes must fit in
+		// both the declared WidthBytes buffer and the allocated DIB pitch
+		// (CVE-2020-24293). WidthBytes is DWORD-padded per the PSD spec, so
+		// it may be larger than width * bpp/8; it must never be smaller.
+		if ((_Width <= 0) || (_Height <= 0) || (_BitPerPixel <= 0) || (_WidthBytes <= 0)) {
+			throw "Invalid PSD image";
+		}
+		if ((_BitPerPixel % 8) != 0) {
+			throw "Invalid PSD image";
+		}
+		const unsigned bytes_pp = (unsigned)_BitPerPixel / 8;
+		const unsigned packed_line = (unsigned)_Width * bytes_pp;
+		if ((packed_line / bytes_pp) != (unsigned)_Width) {
+			throw "Invalid PSD image";
+		}
+		if ((unsigned)_WidthBytes < packed_line) {
+			throw "Invalid PSD image";
+		}
+
 		_dib = FreeImage_Allocate(_Width, _Height, _BitPerPixel);
+		if (_dib == NULL) {
+			throw FI_MSG_ERROR_DIB_MEMORY;
+		}
 		BYTE* dst_line_start = FreeImage_GetScanLine(_dib, _Height - 1);//<*** flipped
+		if (dst_line_start == NULL) {
+			throw "Invalid PSD image";
+		}
 		BYTE* line_start = new BYTE[_WidthBytes];
 		const unsigned dstLineSize = FreeImage_GetPitch(_dib);
+		if (packed_line > dstLineSize) {
+			SAFE_DELETE_ARRAY(line_start);
+			throw "Invalid PSD image";
+		}
 		for(unsigned h = 0; h < (unsigned)_Height; ++h, dst_line_start -= dstLineSize) {//<*** flipped
 			io->read_proc(line_start, _WidthBytes, 1, handle);
 			iTotalData -= _WidthBytes;
-			memcpy(dst_line_start, line_start, _Width * _BitPerPixel / 8);
+			memcpy(dst_line_start, line_start, packed_line);
 		}
 #if FREEIMAGE_COLORORDER == FREEIMAGE_COLORORDER_BGR
 		SwapRedBlue32(_dib);


### PR DESCRIPTION
Fixes #106
Fixes CVE-2020-24293

Depends on #108 (stack parent). Diff vs parent is PSD thumbnail only.

## Summary

Raw PSD thumbnail rows `memcpy`'d `width * bpp/8` into a scanline whose pitch came from `FreeImage_Allocate`, while the source buffer was sized from a separate `WidthBytes` field. All four values are attacker-controlled. If they disagree, the copy writes past the DIB.

`#54` patched `UnpackRLE` (CVE-2020-24294). It did not touch `psdThumbnail::Read`.

## Change

- Reject non-positive dimensions/bpp, bpp not a multiple of 8, and overflow in the packed-row multiply.
- `WidthBytes` is DWORD-padded per the PSD spec, so it may be **larger** than `width*bpp/8`; it must never be smaller (Fedora's equality check would reject valid padded thumbnails).
- Fail `Allocate` and a packed row that does not fit in DIB pitch.
- `memcpy` the packed size, not an unchecked `width*bpp/8`.

## Attack vector

A crafted `.psd` with a malicious thumbnail resource overflows on `FreeImage_Load(FIF_PSD, …)`. NVD 8.8 High.

## Stack

1. #108 — ICO (`#105`)
2. This PR — PSD thumbnail (`#106`)
3. PSD `ReadImageLine` (`#107`)