### PR TITLE
CVE-2020-24295: bound psdParser::ReadImageLine destination writes

### DIFF
--- a/Source/FreeImage/PSDParser.cpp
+++ b/Source/FreeImage/PSDParser.cpp
@@ -1519,6 +1519,11 @@ FIBITMAP* psdParser::ReadImageData(FreeImageIO *io, fi_handle handle) {
 
 	const unsigned dstBpp =  (depth == 1) ? 1 : FreeImage_GetBPP(bitmap)/8;
 	const unsigned dstLineSize = FreeImage_GetPitch(bitmap);
+	if ((nHeight != 0) && (dstLineSize > (~0u / nHeight))) {
+		FreeImage_Unload(bitmap);
+		throw "Invalid PSD image";
+	}
+	const unsigned dst_buffer_size = dstLineSize * nHeight;
 	BYTE* const dst_first_line = FreeImage_GetScanLine(bitmap, nHeight - 1);//<*** flipped
 
 	BYTE* line_start = new BYTE[lineSize]; //< fileline cache
@@ -1533,6 +1538,13 @@ FIBITMAP* psdParser::ReadImageData(FreeImageIO *io, fi_handle handle) {
 				}
 
 				const unsigned channelOffset = GetChannelOffset(bitmap, c) * bytes;
+
+				// Channel writes must fit in the allocated DIB (CVE-2020-24295).
+				if ((channelOffset >= dst_buffer_size) || (lineSize > dst_buffer_size - channelOffset)) {
+					FreeImage_Unload(bitmap);
+					SAFE_DELETE_ARRAY(line_start);
+					throw "Invalid PSD image";
+				}
 
 				BYTE* dst_line_start = dst_first_line + channelOffset;
 				for(unsigned h = 0; h < nHeight; ++h, dst_line_start -= dstLineSize) {//<*** flipped
@@ -1613,6 +1625,15 @@ FIBITMAP* psdParser::ReadImageData(FreeImageIO *io, fi_handle handle) {
 				const BYTE* const line_end = line_start + lineSize;
 
 				const unsigned channelOffset = GetChannelOffset(bitmap, ch) * bytes;
+
+				// Channel writes must fit in the allocated DIB (CVE-2020-24295).
+				if ((channelOffset >= dst_buffer_size) || (lineSize > dst_buffer_size - channelOffset)) {
+					FreeImage_Unload(bitmap);
+					SAFE_DELETE_ARRAY(line_start);
+					SAFE_DELETE_ARRAY(rleLineSizeList);
+					SAFE_DELETE_ARRAY(rle_line_start);
+					throw "Invalid PSD image";
+				}
 
 				BYTE* dst_line_start = dst_first_line + channelOffset;
 				for(unsigned h = 0; h < nHeight; ++h, dst_line_start -= dstLineSize) {//<*** flipped


### PR DESCRIPTION
Fixes #107
Fixes CVE-2020-24295

Depends on #109 (stack parent). Diff vs parent is `ReadImageData` bounds only.

## Summary

`ReadImageData` writes each channel row at `dst_first_line + channelOffset` via `ReadImageLine()` with no check that `channelOffset + lineSize` fits in the allocated DIB. A crafted PSD header can walk that write off the bitmap on both the raw and RLE paths.

`#54` / `62971de` bounded `UnpackRLE`. It did not bound this destination write.

## Change

- Reject `pitch * height` overflow.
- Before `ReadImageLine` (raw and RLE loops), refuse a channel write that does not fit in `dstLineSize * nHeight`.
- Unload the DIB and free line caches on failure so the throw does not leak.

Same `dst_buffer_size` guard as Fedora/Buildroot, applied to both compression paths.

## Attack vector

A crafted `.psd` overflows on `FreeImage_Load(FIF_PSD, …)`. NVD 8.8 High.

## Stack

1. #108 — ICO (`#105`)
2. #109 — PSD thumbnail (`#106`)
3. This PR — PSD `ReadImageLine` (`#107`)